### PR TITLE
Material input fields

### DIFF
--- a/docs/components/sass/abstracts/_tokens.scss
+++ b/docs/components/sass/abstracts/_tokens.scss
@@ -7,6 +7,7 @@
   --token-primary: var(--color-green);
   --token-on-primary: var(--color-on-primary);
 
+
   --token-surface: var(--color-surface);
   --token-on-surface: var(--color-on-surface);
 
@@ -111,9 +112,9 @@
     transparent
   );
 
-    /* ------------------------------------------------------------
+  /* ------------------------------------------------------------
      Pagination Component Tokens
-     ------------------------------------------------------------ */
+  ------------------------------------------------------------ */
 
   --token-pagination-button-size: 2.5rem;
   --token-pagination-icon-size: 1rem;
@@ -132,4 +133,64 @@
   --token-pagination-border-default: 1px solid var(--token-outline);
   --token-pagination-border-disabled: 1px solid var(--token-outline-variant);
 
+  /* ------------------------------------------------------------
+     Input Field Component Tokens
+  ------------------------------------------------------------ */
+
+  --token-input-width: var(--input-field-box-width);
+  --token-input-height: 56px;
+  --token-input-radius: var(--input-field-border-radius);
+
+  --token-input-text-color: var(--color-on-surface);
+  --token-input-text-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+
+  --token-input-label-color: var(--color-on-surface-variant);
+  --token-input-label-color-focus: var(--color-primary);
+  --token-input-label-color-error: var(--input-border-color-error);
+  --token-input-label-color-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+
+  --token-input-supporting-color: var(--color-on-surface-variant);
+  --token-input-supporting-color-error: var(--input-border-color-error);
+  --token-input-supporting-color-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+
+  --token-input-icon-color: var(--color-on-surface-variant);
+  --token-input-icon-color-error: var(--input-border-color-error);
+  --token-input-icon-color-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+
+  --token-input-filled-background: color-mix(in srgb, var(--color-primary) 8%, white);
+  --token-input-filled-background-disabled: color-mix(in srgb, var(--color-on-surface) 12%, transparent);
+
+  --token-input-active-indicator-color: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-active-indicator-hover: var(--color-on-surface);
+  --token-input-active-indicator-focus: var(--color-primary);
+  --token-input-active-indicator-error: var(--input-border-color-error);
+  --token-input-active-indicator-disabled: color-mix(in srgb, var(--color-on-surface) 12%, transparent);
+
+  --token-input-active-indicator-thickness: 1px;
+  --token-input-active-indicator-thickness-focus: 2px;
+
+  --token-input-outline-color: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-outline-hover: var(--color-on-surface);
+  --token-input-outline-focus: var(--color-primary);
+  --token-input-outline-error: var(--input-border-color-error);
+  --token-input-filled-background-hover: color-mix(in srgb, var(--color-primary) 16%, white);
+  --token-input-outline-disabled: color-mix(in srgb, var(--color-on-surface) 12%, transparent);
+
+  --token-input-outline-width: 1px;
+  --token-input-outline-width-focus: 2px;
+
+  --token-input-padding-x: 16px;
+  --token-input-padding-top: 18px;
+  --token-input-padding-bottom: 10px;
+
+  --token-input-icon-size: 24px;
+  --token-input-icon-offset: 12px;
+  --token-input-icon-gap: 16px;
+
+  --token-input-label-font-size: 0.875rem;
+  --token-input-label-font-size-floating: 0.75rem;
+
+  --token-input-supporting-font-size: 0.75rem;
+  --token-input-supporting-gap: 8px;
+  --token-input-width: 360px;
 }

--- a/docs/components/sass/components/_input-fields.scss
+++ b/docs/components/sass/components/_input-fields.scss
@@ -1,746 +1,252 @@
-// -----------------------------------------------------------------------------
-// Input Fields – Shared Base Styles
-// -----------------------------------------------------------------------------
+@use '../abstracts/tokens';
+// --8<-- [start:input]
+[data-theme] {
 
-.input-wrapper {
-  position: relative;
-  width: var(--input-field-box-width);
-  height: 56px; // fixed per Figma
-  font-family: var(--text-font-stack);
+  .input-wrapper {
+    position: relative;
+    width: var(--token-input-width);
+    font-family: var(--text-font-stack);
+  }
 
-  // ========================
-  // Input box (shared)
-  // ========================
+  /* ================= FIELD ================= */
+
   .input-field {
     width: 100%;
-    height: 100%;
-    border-radius: var(--input-field-border-radius, 4px);
-    border: 1px solid var(--input-border-color-default, #C6C6C6);
+    height: 56px;
+    box-sizing: border-box;
+
     padding: 0 16px;
-    font-size: 1rem;
-    font-weight: 600; // semibold
-    line-height: 56px; // center text vertically
-    color: var(--text-color);
-    background: #fff;
+    padding-top: 24px;
 
-    &::placeholder { color: var(--input-placeholder-color, #989898); }
+    font-size: 0.9rem;
+    font-weight: 400;
+    line-height: 24px;
 
-    // Hover
-    &:hover,
-    &.is-hover { border-color: var(--input-border-color-hover, #6F6F6F); }
+    color: var(--token-input-text-color);
+    background: var(--token-input-filled-background);
 
-    // Focused
-    &:focus,
-    &.is-focused {
-      border: 2px solid var(--input-border-color-focus, #247984);
-      outline: none;
-      box-shadow: 0 0 0 2px rgba(36, 121, 132, 0.2);
-    }
+    border: 0;
+    border-bottom: 2px solid var(--token-input-active-indicator-focus);
+    border-radius: 4px 4px 0 0;
 
-    // Error
-    &.error {
-      border-color: var(--input-border-color-error, #D32F2F);
-      color: var(--input-border-color-error, #D32F2F);
-    }
-    &.error::placeholder {
-      color: var(--input-border-color-error, #D32F2F);
-    }
+    outline: none;
+    transition: all 0.15s ease;
 
-    // Disabled
-    &:disabled {
-      border-color: #C6C6C6;
-      background-color: var(--color-light-grey);
-      color: #9D9F9F;
-      cursor: not-allowed;
+    &::placeholder {
+      color: transparent;
     }
   }
 
-  .input-field:disabled ~ .input-icon,
-  .input-field:disabled + .input-label ~ .input-icon {
-    color: #C6C6C6;   // grey
-    opacity: 0.6;
-  }
+  /* ================= LABEL ================= */
 
-
-  // ========================
-  // Labels (default position = unpopulated)
-  // ========================
   .input-label {
     position: absolute;
-    top: 50%;
     left: 16px;
-    transform: translateY(-50%);
-    font-size: 1rem;
-    font-weight: 510;
-    color: #333333;
-    pointer-events: none;
-    transition: all 0.2s ease;
-  }
+    top: 8px;
+    transform: none;
 
-  // Error label
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
-  }
-
-  // Disabled label
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-
-  // Supporting/Helper text
-  .input-helper {
     font-size: 0.75rem;
-    margin-top: 4px;
-    color: #989898;
+    font-weight: 400;
+    line-height: 1rem;
 
-    &.error { color: #D32F2F; }
+    color: var(--token-input-label-color-focus);
+
+    pointer-events: none;
+    transition: 0.15s ease;
   }
 
-  // Icons
+  /* ================= ICONS ================= */
+
   .input-icon {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 1.25rem;
-    color: var(--text-muted);
-    pointer-events: none;
+    top: 16px;
+
+    width: 24px;
+    height: 24px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    color: var(--token-input-icon-color);
+
+    svg {
+      width: 24px;
+      height: 24px;
+      display: block;
+    }
 
     &.leading { left: 12px; }
     &.trailing { right: 12px; }
   }
 
-  .input-field.leading-icon { padding-left: 36px; }
-  .input-field.trailing-icon { padding-right: 36px; }
+  /* ================= ICON PADDING ================= */
 
-  // Simulation helpers for docs
-  .input-field.with-label::placeholder { color: transparent; }
-}
-
-// -----------------------------------------------------------------------------
-// No Icon Variant  (snippet target)
-// -----------------------------------------------------------------------------
-/* === SNIPPET START: no-icon === */
-
-
-// --8<-- [start:no-icon]
-.input-wrapper.no-icon {
-  // Populated: float label above input
-  .input-field.has-value + .input-label {
-    top: 0;                           // sit on top border
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;                 // a touch lighter than input text
-    color: var(--text-color);         // same color as input text
-    background: #fff;                 // mask the border behind label
-    padding: 0 4px;                   // small mask padding
-    line-height: 1;
-  }
-
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;                 // normal text line-height
-    padding-top: 16px;                // 16 + 16 = 32; with borders keeps 56px total
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
-
-  // Focused + populated label color
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
-  }
-
-  // Error label color (already sets input/helper via base)
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
-  }
-
-  // Disabled label color
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-}
-// --8<-- [end:no-icon]
-
-/* === SNIPPET END: no-icon === */
-
-
-/* -------------------------------------------------------------------------- */
-/* Leading Icon Variant                                                       */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:leading-icon]
-.input-wrapper.leading-icon {
-  // Adjust input padding for icon + gap
-  .input-field {
-    padding-left: 52px;  // 12 (padding) + 24 (icon) + 16 (gap) = 52
-  }
-
-  // Icon placement
-  .input-icon.leading {
-    position: absolute;
-    top: 50%;
-    left: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-muted);
-  }
-
-  // Label default (unpopulated) → stays with text start
-  .input-label {
-    left: 52px;   // inline with input text when unpopulated
-  }
-
-  // Populated: float label above border (like No Icon)
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-
-    // ⬇️ shift back to match "No Icon" label position
-    left: 16px;   // instead of 52px
-  }
-
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
-
-  // Focused + populated label color
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
-  }
-
-  // Error label
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
-  }
-
-  // Disabled label
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-}
-// --8<-- [end:leading-icon]
-
-
-/* -------------------------------------------------------------------------- */
-/* Trailing Icon Variant                                                       */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:trailing-icon]
-.input-wrapper.trailing-icon {
-  // Input padding adjusted for icon
-  .input-field {
-    padding-right: 52px; // 12 (padding) + 24 (icon) + 16 (gap)
-  }
-
-  // Icon placement
-  .input-icon.trailing {
-    position: absolute;
-    top: 50%;
-    right: 12px;               // 12px from right edge
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333;
-  }
-
-  // Label default (centered when unpopulated)
-  .input-label {
-    left: 16px; // same as no-icon
-  }
-
-  // Label floats when populated
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-  }
-
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
-
-  // Focused label
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
-  }
-
-  // Error label
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
-  }
-
-  // Disabled label
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-}
-// --8<-- [end:trailing-icon]
-
-
-/* -------------------------------------------------------------------------- */
-/* No Icon + Supporting Text Variant                                          */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:no-icon-supporting]
-.input-wrapper.no-icon-supporting {
-  // Float label when populated (same as no-icon)
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-  }
-
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
-
-  // Supporting text styles
-  .input-helper {
-    font-size: 0.75rem;
-    line-height: 1.4;
-    margin-top: 4px;           // 4px gap below box
-    margin-left: 16px;         // align with label/input text
-    margin-right: 16px;
-    color: #6F6F6F;
-  }
-
-  .input-helper.error {
-    color: var(--input-supporting-text-error, #D32F2F);
-  }
-
-  // Disabled state
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-  .input-field:disabled ~ .input-helper {
-    color: #C6C6C6;
-  }
-}
-// --8<-- [end:no-icon-supporting]
-
-/* -------------------------------------------------------------------------- */
-/* Leading Icon + Supporting Text Variant                                     */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:leading-icon-supporting]
-.input-wrapper.leading-icon-supporting {
-  // Adjust input padding for icon + gap
-  .input-field {
-    padding-left: 52px; // 12 (padding) + 24 (icon) + 16 (gap) = 52
+  .input-field.leading-icon {
+    padding-left: 52px;
   }
 
-  // Leading icon placement
-  .input-icon.leading {
-    position: absolute;
-    top: 50%;
-    left: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333; // dark by default
+  .input-field.trailing-icon {
+    padding-right: 52px;
   }
 
-  // Label (unpopulated, aligned with text start)
-  .input-label {
-    left: 52px; // after the icon
+  .input-field.leading-icon ~ .input-label {
+    left: 52px;
   }
 
-  // Populated: float label above, shift back to 16px like "no icon"
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-    left: 16px; // matches no-icon float position
+  .input-field.error ~ .input-icon {
+    color: var(--token-input-icon-color-error);
   }
 
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
+  .input-field:disabled ~ .input-icon {
+    color: var(--token-input-icon-color-disabled);
   }
 
-  // Supporting text
-  .input-helper {
-    font-size: 0.75rem;
-    line-height: 1.4;
-    margin-top: 4px;   // 4px below field
-    margin-left: 16px; // inset matches label/input
-    margin-right: 16px;
-    color: #6F6F6F;
-  }
-
-  .input-helper.error {
-    color: var(--input-supporting-text-error, #D32F2F);
-  }
-
-  // Focused + populated label
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
-  }
-
-  // Disabled state
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-  .input-field:disabled ~ .input-helper {
-    color: #C6C6C6;
-  }
-  .input-field:disabled ~ .input-icon.leading {
-    color: #C6C6C6;
-  }
-}
-// --8<-- [end:leading-icon-supporting]
-
-/* -------------------------------------------------------------------------- */
-/* Trailing Icon + Supporting Text Variant                                    */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:trailing-icon-supporting]
-.input-wrapper.trailing-icon-supporting {
-  // Input box
-  .input-field {
-    padding-right: 52px;  // 12 (padding) + 24 (icon) + 16 (gap)
-  }
-
-  // Trailing icon
-  .input-icon.trailing {
-    position: absolute;
-    top: 50%;
-    right: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333;
-  }
-
-  // Label (default: centered when unpopulated)
-  .input-label {
-    left: 16px; // same as No Icon
-  }
-
-  // Floating label when populated
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-  }
-
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
-
-  // Focused label
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
-  }
-
-  // Error label
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
-  }
-
-  // Disabled label + icon
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-  .input-field:disabled ~ .input-icon.trailing {
-    color: #9D9F9F; // disabled grey
-  }
-
-  // Supporting / helper text
-  .input-helper {
-    font-size: 0.75rem;
-    margin-top: 4px;   // 4px gap under input box
-    margin-left: 16px; // 16px inset left
-    margin-right: 16px;
-    color: #989898;
-
-    &.error { color: #D32F2F; }
-    &.disabled { color: #C6C6C6; }
-  }
-}
-// --8<-- [end:trailing-icon-supporting]
-
-
-/* -------------------------------------------------------------------------- */
-/* Leading + Trailing Icons Variant                                           */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:leading-trailing-icon]
-.input-wrapper.leading-trailing-icon {
-  // Adjust input padding for both icons
-  .input-field {
-    padding-left: 52px;  // 12 + 24 + 16 = 52px before text
-    padding-right: 52px; // 12 + 24 + 16 = 52px after text
-  }
-
-  // Leading icon placement
-  .input-icon.leading {
-    position: absolute;
-    top: 50%;
-    left: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333;
-  }
-
-  // Trailing icon placement
-  .input-icon.trailing {
-    position: absolute;
-    top: 50%;
-    right: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333;
-  }
-
-  // Label (default)
-  .input-label {
-    left: 52px; // starts after leading icon
-  }
-
-  // Populated: float label above input
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-    left: 16px; // ⬅️ align same as No Icon when floating
-  }
-
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
-
-  // Focused + populated label
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
-  }
-
-  // Error label + icons
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
-  }
-  .input-field.error ~ .input-icon.leading,
-  .input-field.error ~ .input-icon.trailing {
-    color: #D32F2F;
-  }
-
-  // Disabled label + icons
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
-  }
-  .input-field:disabled ~ .input-icon.leading,
-  .input-field:disabled ~ .input-icon.trailing {
-    color: #C6C6C6;
-    opacity: 0.6;
-  }
-}
-// --8<-- [end:leading-trailing-icon]
-
-/* -------------------------------------------------------------------------- */
-/* Leading + Trailing Icons + Supporting Text Variant                          */
-/* -------------------------------------------------------------------------- */
-
-// --8<-- [start:leading-trailing-icon-supporting]
-.input-wrapper.leading-trailing-icon-supporting {
-  // Adjust input padding for both icons
-  .input-field {
-    padding-left: 52px;  // 12 + 24 + 16 = 52px before text
-    padding-right: 52px; // 12 + 24 + 16 = 52px after text
-  }
-
-  // Leading icon placement
-  .input-icon.leading {
-    position: absolute;
-    top: 50%;
-    left: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333;
-  }
-
-  // Trailing icon placement
-  .input-icon.trailing {
-    position: absolute;
-    top: 50%;
-    right: 12px;
-    width: 24px;
-    height: 24px;
-    transform: translateY(-50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #333333;
-  }
-
-  // Label (default, when unpopulated)
-  .input-label {
-    left: 52px; // starts after leading icon
-  }
-
-  // Populated: float label above input
-  .input-field.has-value + .input-label {
-    top: 0;
-    transform: translateY(-50%);
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--text-color);
-    background: #fff;
-    padding: 0 4px;
-    line-height: 1;
-    left: 16px; // ⬅️ align same as No Icon when floating
-  }
-
-  // Input text when populated
-  .input-field.has-value {
-    line-height: 1.5;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    font-weight: 600;
-  }
+  /* ================= SUPPORTING TEXT ================= */
 
-  // Supporting text
   .input-helper {
     margin-top: 4px;
+    margin-left: 16px;
+
     font-size: 0.75rem;
-    color: #989898;
 
-    &.error {
-      color: #D32F2F;
-    }
+    color: var(--token-input-supporting-color);
   }
 
-  // Focused + populated label
-  .input-field.has-value.is-focused + .input-label {
-    color: var(--input-border-color-focus, #247984);
+  .input-helper.error {
+    color: var(--token-input-supporting-color-error);
   }
 
-  // Error label + icons
-  .input-field.error + .input-label {
-    color: var(--input-label-color-error, #D32F2F);
+  .input-field:disabled ~ .input-helper {
+    color: var(--token-input-supporting-color-disabled);
   }
-  .input-field.error ~ .input-icon.leading,
+
+  /* ================= HOVER STATES ================= */
+
+  .input-field.is-hover:hover {
+    background: var(--token-input-filled-background-hover);
+    border-bottom-color: var(--token-input-active-indicator-hover);
+  }
+
+  .input-wrapper.input-outlined .input-field.is-hover:hover {
+    border-color: var(--token-input-outline-hover);
+  }
+
+  /* ================= FOCUS STATES ================= */
+
+  .input-field.is-focus:focus {
+    border-bottom: 3px solid var(--token-input-active-indicator-focus);
+  }
+
+  .input-field.is-focus:focus ~ .input-label {
+    color: var(--token-input-label-color-focus);
+  }
+
+  .input-wrapper.input-outlined .input-field.is-focus:focus {
+    border: 3px solid var(--token-input-outline-focus);
+  }
+
+  .input-wrapper.input-outlined .input-field.is-focus:focus ~ .input-label {
+    color: var(--token-input-label-color-focus);
+  }
+
+  /* ================= ERROR STATES ================= */
+
+  .input-field.error {
+    border-bottom: 3px solid var(--token-input-active-indicator-error);
+  }
+
+  .input-field.error ~ .input-label {
+    color: var(--token-input-label-color-error);
+  }
+
+  .input-field.error ~ .input-helper {
+    color: var(--token-input-supporting-color-error);
+  }
+
   .input-field.error ~ .input-icon.trailing {
-    color: #D32F2F;
+    color: var(--token-input-icon-color-error);
   }
 
-  // Disabled label + icons
-  .input-field:disabled + .input-label {
-    color: var(--input-label-color-disabled, #C6C6C6);
+  /* Outlined error */
+  .input-wrapper.input-outlined .input-field.error {
+    border: 3px solid var(--token-input-outline-error);
   }
-  .input-field:disabled ~ .input-icon.leading,
-  .input-field:disabled ~ .input-icon.trailing {
-    color: #C6C6C6;
-    opacity: 0.6;
+
+  /* ================= DISABLED STATES ================= */
+
+  .input-field:disabled {
+    border-bottom-color: var(--token-input-active-indicator-disabled);
+    color: var(--token-input-text-disabled);
+    cursor: not-allowed;
   }
+
+  .input-field:disabled ~ .input-label {
+    color: var(--token-input-label-color-disabled);
+  }
+
+  .input-field:disabled ~ .input-helper {
+    color: var(--token-input-supporting-color-disabled);
+  }
+
+  .input-field:disabled ~ .input-icon {
+    color: var(--token-input-icon-color-disabled);
+  }
+
+  /* Outlined disabled */
+  .input-wrapper.input-outlined .input-field:disabled {
+    border-color: var(--token-input-outline-disabled);
+  }
+
+  /* ================= OUTLINED ================= */
+
+  .input-wrapper.input-outlined .input-field {
+    background: #fff;
+
+    border: 2px solid var(--token-input-outline-focus);
+    border-radius: 4px;
+
+    padding-top: 16px;
+    padding-bottom: 16px;
+  }
+
+  .state-hover .input-wrapper.input-outlined .input-field:hover {
+    border-color: var(--token-input-outline-hover);
+  }
+
+  .input-wrapper.input-outlined .input-field.error {
+    border: 3px solid var(--token-input-outline-error);
+  }
+
+  .input-wrapper.input-outlined .input-field:disabled {
+    border-color: var(--token-input-outline-disabled);
+  }
+
+  .input-wrapper.input-outlined .input-label {
+    background: #fff;
+    padding: 0 4px;
+    top: 0;
+    transform: translateY(-50%);
+    z-index: 1;
+  }
+
+  .input-wrapper.input-outlined .input-field.leading-icon ~ .input-label {
+    left: 16px;
+  }
+
+  /* ================= DEMO BOX ================= */
+
+  .state-box {
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    padding: 24px;
+    margin: 8px 0 16px;
+  }
+
 }
-// --8<-- [end:leading-trailing-icon-supporting]
 
-
-
-// -----------------------------------------------------------------------------
-// State container (for docs only)
-// -----------------------------------------------------------------------------
-.state-box {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 24px;
-  margin: 8px 0 16px;
-
-  background: var(--md-code-bg-color, #f6f8fa);
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-}
-
-/* Bold headings in docs */
-.md-typeset h1,
-.md-typeset h2 {
-  font-weight: 700 !important;
-}
-
-/* Thicker tab underline */
-.md-typeset .tabbed-labels > label[for].md-tabs__item--active::after,
-.md-typeset .tabbed-labels > label[for].md-tabs__link--active::after {
-  height: 4px !important;
-  background-color: var(--md-accent-fg-color, #247984) !important;
-}
+// --8<-- [end:input]

--- a/docs/dist/main.css
+++ b/docs/dist/main.css
@@ -178,8 +178,8 @@
     transparent
   );
   /* ------------------------------------------------------------
-   Pagination Component Tokens
-   ------------------------------------------------------------ */
+     Pagination Component Tokens
+  ------------------------------------------------------------ */
   --token-pagination-button-size: 2.5rem;
   --token-pagination-icon-size: 1rem;
   /* Colors */
@@ -193,6 +193,52 @@
   /* Borders (for ctrl buttons) */
   --token-pagination-border-default: 1px solid var(--token-outline);
   --token-pagination-border-disabled: 1px solid var(--token-outline-variant);
+  /* ------------------------------------------------------------
+     Input Field Component Tokens
+  ------------------------------------------------------------ */
+  --token-input-width: var(--input-field-box-width);
+  --token-input-height: 56px;
+  --token-input-radius: var(--input-field-border-radius);
+  --token-input-text-color: var(--color-on-surface);
+  --token-input-text-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-label-color: var(--color-on-surface-variant);
+  --token-input-label-color-focus: var(--color-primary);
+  --token-input-label-color-error: var(--input-border-color-error);
+  --token-input-label-color-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-supporting-color: var(--color-on-surface-variant);
+  --token-input-supporting-color-error: var(--input-border-color-error);
+  --token-input-supporting-color-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-icon-color: var(--color-on-surface-variant);
+  --token-input-icon-color-error: var(--input-border-color-error);
+  --token-input-icon-color-disabled: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-filled-background: color-mix(in srgb, var(--color-primary) 8%, white);
+  --token-input-filled-background-disabled: color-mix(in srgb, var(--color-on-surface) 12%, transparent);
+  --token-input-active-indicator-color: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-active-indicator-hover: var(--color-on-surface);
+  --token-input-active-indicator-focus: var(--color-primary);
+  --token-input-active-indicator-error: var(--input-border-color-error);
+  --token-input-active-indicator-disabled: color-mix(in srgb, var(--color-on-surface) 12%, transparent);
+  --token-input-active-indicator-thickness: 1px;
+  --token-input-active-indicator-thickness-focus: 2px;
+  --token-input-outline-color: color-mix(in srgb, var(--color-on-surface) 38%, transparent);
+  --token-input-outline-hover: var(--color-on-surface);
+  --token-input-outline-focus: var(--color-primary);
+  --token-input-outline-error: var(--input-border-color-error);
+  --token-input-filled-background-hover: color-mix(in srgb, var(--color-primary) 16%, white);
+  --token-input-outline-disabled: color-mix(in srgb, var(--color-on-surface) 12%, transparent);
+  --token-input-outline-width: 1px;
+  --token-input-outline-width-focus: 2px;
+  --token-input-padding-x: 16px;
+  --token-input-padding-top: 18px;
+  --token-input-padding-bottom: 10px;
+  --token-input-icon-size: 24px;
+  --token-input-icon-offset: 12px;
+  --token-input-icon-gap: 16px;
+  --token-input-label-font-size: 0.875rem;
+  --token-input-label-font-size-floating: 0.75rem;
+  --token-input-supporting-font-size: 0.75rem;
+  --token-input-supporting-gap: 8px;
+  --token-input-width: 360px;
 }
 
 body {
@@ -442,559 +488,214 @@ input[type=radio]:checked :hover {
   opacity: 0.3;
 }
 
-.input-wrapper {
+[data-theme] .input-wrapper {
   position: relative;
-  width: var(--input-field-box-width);
-  height: 56px;
+  width: var(--token-input-width);
   font-family: var(--text-font-stack);
 }
-.input-wrapper .input-field {
+[data-theme] {
+  /* ================= FIELD ================= */
+}
+[data-theme] .input-field {
   width: 100%;
-  height: 100%;
-  border-radius: var(--input-field-border-radius, 4px);
-  border: 1px solid var(--input-border-color-default, #C6C6C6);
+  height: 56px;
+  box-sizing: border-box;
   padding: 0 16px;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 56px;
-  color: var(--text-color);
-  background: #fff;
-}
-.input-wrapper .input-field::placeholder {
-  color: var(--input-placeholder-color, #989898);
-}
-.input-wrapper .input-field:hover, .input-wrapper .input-field.is-hover {
-  border-color: var(--input-border-color-hover, #6F6F6F);
-}
-.input-wrapper .input-field:focus, .input-wrapper .input-field.is-focused {
-  border: 2px solid var(--input-border-color-focus, #247984);
+  padding-top: 24px;
+  font-size: 0.9rem;
+  font-weight: 400;
+  line-height: 24px;
+  color: var(--token-input-text-color);
+  background: var(--token-input-filled-background);
+  border: 0;
+  border-bottom: 2px solid var(--token-input-active-indicator-focus);
+  border-radius: 4px 4px 0 0;
   outline: none;
-  box-shadow: 0 0 0 2px rgba(36, 121, 132, 0.2);
+  transition: all 0.15s ease;
 }
-.input-wrapper .input-field.error {
-  border-color: var(--input-border-color-error, #D32F2F);
-  color: var(--input-border-color-error, #D32F2F);
-}
-.input-wrapper .input-field.error::placeholder {
-  color: var(--input-border-color-error, #D32F2F);
-}
-.input-wrapper .input-field:disabled {
-  border-color: #C6C6C6;
-  background-color: var(--color-light-grey);
-  color: #9D9F9F;
-  cursor: not-allowed;
-}
-.input-wrapper .input-field:disabled ~ .input-icon,
-.input-wrapper .input-field:disabled + .input-label ~ .input-icon {
-  color: #C6C6C6;
-  opacity: 0.6;
-}
-.input-wrapper .input-label {
-  position: absolute;
-  top: 50%;
-  left: 16px;
-  transform: translateY(-50%);
-  font-size: 1rem;
-  font-weight: 510;
-  color: #333333;
-  pointer-events: none;
-  transition: all 0.2s ease;
-}
-.input-wrapper .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
-}
-.input-wrapper .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-.input-wrapper .input-helper {
-  font-size: 0.75rem;
-  margin-top: 4px;
-  color: #989898;
-}
-.input-wrapper .input-helper.error {
-  color: #D32F2F;
-}
-.input-wrapper .input-icon {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 1.25rem;
-  color: var(--text-muted);
-  pointer-events: none;
-}
-.input-wrapper .input-icon.leading {
-  left: 12px;
-}
-.input-wrapper .input-icon.trailing {
-  right: 12px;
-}
-.input-wrapper .input-field.leading-icon {
-  padding-left: 36px;
-}
-.input-wrapper .input-field.trailing-icon {
-  padding-right: 36px;
-}
-.input-wrapper .input-field.with-label::placeholder {
+[data-theme] .input-field::placeholder {
   color: transparent;
 }
-
-/* === SNIPPET START: no-icon === */
-.input-wrapper.no-icon .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
+[data-theme] {
+  /* ================= LABEL ================= */
+}
+[data-theme] .input-label {
+  position: absolute;
+  left: 16px;
+  top: 8px;
+  transform: none;
   font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
+  font-weight: 400;
+  line-height: 1rem;
+  color: var(--token-input-label-color-focus);
+  pointer-events: none;
+  transition: 0.15s ease;
 }
-.input-wrapper.no-icon .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
+[data-theme] {
+  /* ================= ICONS ================= */
 }
-.input-wrapper.no-icon .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
+[data-theme] .input-icon {
+  position: absolute;
+  top: 16px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--token-input-icon-color);
 }
-.input-wrapper.no-icon .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
+[data-theme] .input-icon svg {
+  width: 24px;
+  height: 24px;
+  display: block;
 }
-.input-wrapper.no-icon .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
+[data-theme] .input-icon.leading {
+  left: 12px;
 }
-
-/* === SNIPPET END: no-icon === */
-/* -------------------------------------------------------------------------- */
-/* Leading Icon Variant                                                       */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.leading-icon .input-field {
+[data-theme] .input-icon.trailing {
+  right: 12px;
+}
+[data-theme] {
+  /* ================= ICON PADDING ================= */
+}
+[data-theme] .input-field.leading-icon {
   padding-left: 52px;
 }
-.input-wrapper.leading-icon .input-icon.leading {
-  position: absolute;
-  top: 50%;
-  left: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-}
-.input-wrapper.leading-icon .input-label {
-  left: 52px;
-}
-.input-wrapper.leading-icon .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
-  left: 16px;
-}
-.input-wrapper.leading-icon .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
-}
-.input-wrapper.leading-icon .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
-}
-.input-wrapper.leading-icon .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
-}
-.input-wrapper.leading-icon .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-
-/* -------------------------------------------------------------------------- */
-/* Trailing Icon Variant                                                       */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.trailing-icon .input-field {
+[data-theme] .input-field.trailing-icon {
   padding-right: 52px;
 }
-.input-wrapper.trailing-icon .input-icon.trailing {
-  position: absolute;
-  top: 50%;
-  right: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
+[data-theme] .input-field.leading-icon ~ .input-label {
+  left: 52px;
 }
-.input-wrapper.trailing-icon .input-label {
-  left: 16px;
+[data-theme] .input-field.error ~ .input-icon {
+  color: var(--token-input-icon-color-error);
 }
-.input-wrapper.trailing-icon .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
+[data-theme] .input-field:disabled ~ .input-icon {
+  color: var(--token-input-icon-color-disabled);
 }
-.input-wrapper.trailing-icon .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
+[data-theme] {
+  /* ================= SUPPORTING TEXT ================= */
 }
-.input-wrapper.trailing-icon .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
-}
-.input-wrapper.trailing-icon .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
-}
-.input-wrapper.trailing-icon .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-
-/* -------------------------------------------------------------------------- */
-/* No Icon + Supporting Text Variant                                          */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.no-icon-supporting .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
-}
-.input-wrapper.no-icon-supporting .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
-}
-.input-wrapper.no-icon-supporting .input-helper {
-  font-size: 0.75rem;
-  line-height: 1.4;
+[data-theme] .input-helper {
   margin-top: 4px;
   margin-left: 16px;
-  margin-right: 16px;
-  color: #6F6F6F;
-}
-.input-wrapper.no-icon-supporting .input-helper.error {
-  color: var(--input-supporting-text-error, #D32F2F);
-}
-.input-wrapper.no-icon-supporting .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-.input-wrapper.no-icon-supporting .input-field:disabled ~ .input-helper {
-  color: #C6C6C6;
-}
-
-/* -------------------------------------------------------------------------- */
-/* Leading Icon + Supporting Text Variant                                     */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.leading-icon-supporting .input-field {
-  padding-left: 52px;
-}
-.input-wrapper.leading-icon-supporting .input-icon.leading {
-  position: absolute;
-  top: 50%;
-  left: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
-}
-.input-wrapper.leading-icon-supporting .input-label {
-  left: 52px;
-}
-.input-wrapper.leading-icon-supporting .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
   font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
-  left: 16px;
+  color: var(--token-input-supporting-color);
 }
-.input-wrapper.leading-icon-supporting .input-field.has-value {
-  line-height: 1.5;
+[data-theme] .input-helper.error {
+  color: var(--token-input-supporting-color-error);
+}
+[data-theme] .input-field:disabled ~ .input-helper {
+  color: var(--token-input-supporting-color-disabled);
+}
+[data-theme] {
+  /* ================= HOVER STATES ================= */
+}
+[data-theme] .input-field.is-hover:hover {
+  background: var(--token-input-filled-background-hover);
+  border-bottom-color: var(--token-input-active-indicator-hover);
+}
+[data-theme] .input-wrapper.input-outlined .input-field.is-hover:hover {
+  border-color: var(--token-input-outline-hover);
+}
+[data-theme] {
+  /* ================= FOCUS STATES ================= */
+}
+[data-theme] .input-field.is-focus:focus {
+  border-bottom: 3px solid var(--token-input-active-indicator-focus);
+}
+[data-theme] .input-field.is-focus:focus ~ .input-label {
+  color: var(--token-input-label-color-focus);
+}
+[data-theme] .input-wrapper.input-outlined .input-field.is-focus:focus {
+  border: 3px solid var(--token-input-outline-focus);
+}
+[data-theme] .input-wrapper.input-outlined .input-field.is-focus:focus ~ .input-label {
+  color: var(--token-input-label-color-focus);
+}
+[data-theme] {
+  /* ================= ERROR STATES ================= */
+}
+[data-theme] .input-field.error {
+  border-bottom: 3px solid var(--token-input-active-indicator-error);
+}
+[data-theme] .input-field.error ~ .input-label {
+  color: var(--token-input-label-color-error);
+}
+[data-theme] .input-field.error ~ .input-helper {
+  color: var(--token-input-supporting-color-error);
+}
+[data-theme] .input-field.error ~ .input-icon.trailing {
+  color: var(--token-input-icon-color-error);
+}
+[data-theme] {
+  /* Outlined error */
+}
+[data-theme] .input-wrapper.input-outlined .input-field.error {
+  border: 3px solid var(--token-input-outline-error);
+}
+[data-theme] {
+  /* ================= DISABLED STATES ================= */
+}
+[data-theme] .input-field:disabled {
+  border-bottom-color: var(--token-input-active-indicator-disabled);
+  color: var(--token-input-text-disabled);
+  cursor: not-allowed;
+}
+[data-theme] .input-field:disabled ~ .input-label {
+  color: var(--token-input-label-color-disabled);
+}
+[data-theme] .input-field:disabled ~ .input-helper {
+  color: var(--token-input-supporting-color-disabled);
+}
+[data-theme] .input-field:disabled ~ .input-icon {
+  color: var(--token-input-icon-color-disabled);
+}
+[data-theme] {
+  /* Outlined disabled */
+}
+[data-theme] .input-wrapper.input-outlined .input-field:disabled {
+  border-color: var(--token-input-outline-disabled);
+}
+[data-theme] {
+  /* ================= OUTLINED ================= */
+}
+[data-theme] .input-wrapper.input-outlined .input-field {
+  background: #fff;
+  border: 2px solid var(--token-input-outline-focus);
+  border-radius: 4px;
   padding-top: 16px;
   padding-bottom: 16px;
-  font-weight: 600;
 }
-.input-wrapper.leading-icon-supporting .input-helper {
-  font-size: 0.75rem;
-  line-height: 1.4;
-  margin-top: 4px;
-  margin-left: 16px;
-  margin-right: 16px;
-  color: #6F6F6F;
+[data-theme] .state-hover .input-wrapper.input-outlined .input-field:hover {
+  border-color: var(--token-input-outline-hover);
 }
-.input-wrapper.leading-icon-supporting .input-helper.error {
-  color: var(--input-supporting-text-error, #D32F2F);
+[data-theme] .input-wrapper.input-outlined .input-field.error {
+  border: 3px solid var(--token-input-outline-error);
 }
-.input-wrapper.leading-icon-supporting .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
+[data-theme] .input-wrapper.input-outlined .input-field:disabled {
+  border-color: var(--token-input-outline-disabled);
 }
-.input-wrapper.leading-icon-supporting .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-.input-wrapper.leading-icon-supporting .input-field:disabled ~ .input-helper {
-  color: #C6C6C6;
-}
-.input-wrapper.leading-icon-supporting .input-field:disabled ~ .input-icon.leading {
-  color: #C6C6C6;
-}
-
-/* -------------------------------------------------------------------------- */
-/* Trailing Icon + Supporting Text Variant                                    */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.trailing-icon-supporting .input-field {
-  padding-right: 52px;
-}
-.input-wrapper.trailing-icon-supporting .input-icon.trailing {
-  position: absolute;
-  top: 50%;
-  right: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
-}
-.input-wrapper.trailing-icon-supporting .input-label {
-  left: 16px;
-}
-.input-wrapper.trailing-icon-supporting .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
+[data-theme] .input-wrapper.input-outlined .input-label {
   background: #fff;
   padding: 0 4px;
-  line-height: 1;
-}
-.input-wrapper.trailing-icon-supporting .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
-}
-.input-wrapper.trailing-icon-supporting .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
-}
-.input-wrapper.trailing-icon-supporting .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
-}
-.input-wrapper.trailing-icon-supporting .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-.input-wrapper.trailing-icon-supporting .input-field:disabled ~ .input-icon.trailing {
-  color: #9D9F9F;
-}
-.input-wrapper.trailing-icon-supporting .input-helper {
-  font-size: 0.75rem;
-  margin-top: 4px;
-  margin-left: 16px;
-  margin-right: 16px;
-  color: #989898;
-}
-.input-wrapper.trailing-icon-supporting .input-helper.error {
-  color: #D32F2F;
-}
-.input-wrapper.trailing-icon-supporting .input-helper.disabled {
-  color: #C6C6C6;
-}
-
-/* -------------------------------------------------------------------------- */
-/* Leading + Trailing Icons Variant                                           */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.leading-trailing-icon .input-field {
-  padding-left: 52px;
-  padding-right: 52px;
-}
-.input-wrapper.leading-trailing-icon .input-icon.leading {
-  position: absolute;
-  top: 50%;
-  left: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
-}
-.input-wrapper.leading-trailing-icon .input-icon.trailing {
-  position: absolute;
-  top: 50%;
-  right: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
-}
-.input-wrapper.leading-trailing-icon .input-label {
-  left: 52px;
-}
-.input-wrapper.leading-trailing-icon .input-field.has-value + .input-label {
   top: 0;
   transform: translateY(-50%);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
+  z-index: 1;
+}
+[data-theme] .input-wrapper.input-outlined .input-field.leading-icon ~ .input-label {
   left: 16px;
 }
-.input-wrapper.leading-trailing-icon .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
+[data-theme] {
+  /* ================= DEMO BOX ================= */
 }
-.input-wrapper.leading-trailing-icon .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
-}
-.input-wrapper.leading-trailing-icon .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
-}
-.input-wrapper.leading-trailing-icon .input-field.error ~ .input-icon.leading,
-.input-wrapper.leading-trailing-icon .input-field.error ~ .input-icon.trailing {
-  color: #D32F2F;
-}
-.input-wrapper.leading-trailing-icon .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-.input-wrapper.leading-trailing-icon .input-field:disabled ~ .input-icon.leading,
-.input-wrapper.leading-trailing-icon .input-field:disabled ~ .input-icon.trailing {
-  color: #C6C6C6;
-  opacity: 0.6;
-}
-
-/* -------------------------------------------------------------------------- */
-/* Leading + Trailing Icons + Supporting Text Variant                          */
-/* -------------------------------------------------------------------------- */
-.input-wrapper.leading-trailing-icon-supporting .input-field {
-  padding-left: 52px;
-  padding-right: 52px;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-icon.leading {
-  position: absolute;
-  top: 50%;
-  left: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-icon.trailing {
-  position: absolute;
-  top: 50%;
-  right: 12px;
-  width: 24px;
-  height: 24px;
-  transform: translateY(-50%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #333333;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-label {
-  left: 52px;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field.has-value + .input-label {
-  top: 0;
-  transform: translateY(-50%);
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--text-color);
-  background: #fff;
-  padding: 0 4px;
-  line-height: 1;
-  left: 16px;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field.has-value {
-  line-height: 1.5;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  font-weight: 600;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-helper {
-  margin-top: 4px;
-  font-size: 0.75rem;
-  color: #989898;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-helper.error {
-  color: #D32F2F;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field.has-value.is-focused + .input-label {
-  color: var(--input-border-color-focus, #247984);
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field.error + .input-label {
-  color: var(--input-label-color-error, #D32F2F);
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field.error ~ .input-icon.leading,
-.input-wrapper.leading-trailing-icon-supporting .input-field.error ~ .input-icon.trailing {
-  color: #D32F2F;
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field:disabled + .input-label {
-  color: var(--input-label-color-disabled, #C6C6C6);
-}
-.input-wrapper.leading-trailing-icon-supporting .input-field:disabled ~ .input-icon.leading,
-.input-wrapper.leading-trailing-icon-supporting .input-field:disabled ~ .input-icon.trailing {
-  color: #C6C6C6;
-  opacity: 0.6;
-}
-
-.state-box {
+[data-theme] .state-box {
   width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 24px;
   margin: 8px 0 16px;
-  background: var(--md-code-bg-color, #f6f8fa);
-  border: none;
-  border-radius: 0;
-  box-shadow: none;
-}
-
-/* Bold headings in docs */
-.md-typeset h1,
-.md-typeset h2 {
-  font-weight: 700 !important;
-}
-
-/* Thicker tab underline */
-.md-typeset .tabbed-labels > label[for].md-tabs__item--active::after,
-.md-typeset .tabbed-labels > label[for].md-tabs__link--active::after {
-  height: 4px !important;
-  background-color: var(--md-accent-fg-color, #247984) !important;
 }
 
 .textarea-field-container {

--- a/docs/input-fields.md
+++ b/docs/input-fields.md
@@ -5,2908 +5,4796 @@ hide:
 
 <div class="page-header">
   <h1>Input Fields</h1>
-  <a href="https://www.figma.com/design/TTRS2FWXsrymHYpPJL1IdH/Internship-Team-Main-file?node-id=2-54&p=f&t=LYP42X6K0roEV7TT-0" target="_blank" class="figma-link"> Figma <span class="material-icons-outlined">open_in_new</span>
-  </a>
 </div>
 
 ## Class
 
 === "No Icon"
-    <div class="state-box">
-      <div class="input-wrapper no-icon">
-        <input id="noicon-preview" class="input-field with-label" type="text" aria-label="Preview input field" readonly>
-        <label class="input-label" for="noicon-preview">Label Text</label>
-      </div>
+    <div data-theme>
+        <div class="state-box">
+            <div class="input-wrapper input-filled">
+                <input
+                    id="ue"
+                    class="input-field"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="ue">Label</label>
+            </div>
+        </div>
     </div>
 
     <h2 class="no-toc">States</h2>
 
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper">
-                <input id="noicon-ue" class="input-field with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="noicon-ue">Label Text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper">
-                <input id="noicon-ue" class="input-field with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="noicon-ue">Label Text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
-            ```
-
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pe" class="input-field has-value" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="noicon-pe">Label text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pe" class="input-field has-value" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="noicon-pe">Label text</label>
-            </div>
-
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
-            ```
-
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper">
-                <input id="noicon-uh" class="input-field with-label is-hover" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="noicon-uh">Label Text</label>
-            </div>
-        </div>
-        
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper">
-                <input id="noicon-uh" class="input-field with-label is-hover" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="noicon-uh">Label Text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
-            ```
-
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper no-icon">
-                <input id="noicon-ph" class="input-field has-value is-hover" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="noicon-ph">Label text</label>
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined">
+                    <input
+                        id="ue"
+                        class="input-field"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon">
-                <input id="noicon-ph" class="input-field has-value is-hover" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="noicon-ph">Label text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined">
+                        <input
+                            id="ue"
+                            class="input-field"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper">
-                <input id="noicon-uf" class="input-field with-label is-focused" 
-                    type="text" placeholder="Placeholder" readonly>
-                <label class="input-label" for="noicon-uf">Label Text</label>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled">
+                    <input
+                        id="ue"
+                        class="input-field"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper">
-                <input id="noicon-uf" class="input-field with-label is-focused" 
-                    type="text" placeholder="Placeholder" readonly>
-                <label class="input-label" for="noicon-uf">Label Text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled">
+                        <input
+                            id="ue"
+                            class="input-field"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pf" class="input-field has-value is-focused" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="noicon-pf">Label text</label>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined">
+                    <input
+                    class="input-field is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pf" class="input-field has-value is-focused" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="noicon-pf">Label text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined">
+                        <input
+                        class="input-field is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper">
-                <input id="noicon-uee" class="input-field error with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="noicon-uee">Label Text</label>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled">
+                    <input
+                        id="ue"
+                        class="input-field is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper">
-                <input id="noicon-uee" class="input-field error with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="noicon-uee">Label Text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled">
+                        <input
+                            id="ue"
+                            class="input-field is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pee" class="input-field error has-value" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="noicon-pee">Label text</label>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined">
+                    <input
+                    class="input-field is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pee" class="input-field error has-value" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="noicon-pee">Label text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined">
+                        <input
+                        class="input-field is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Disabled"
-
-        <div class="state-box">
-            <div class="input-wrapper">
-                <input id="noicon-ud" class="input-field with-label" type="text" disabled placeholder="Placeholder" readonly aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="noicon-ud">Label Text</label>
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled">
+                    <input
+                        id="ue"
+                        class="input-field is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
-
         === "HTML"
             ```html
-            <div class="input-wrapper">
-                <input id="noicon-ud" class="input-field with-label" type="text" disabled placeholder="Placeholder" readonly aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="noicon-ud">Label Text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled">
+                        <input
+                            id="ue"
+                            class="input-field is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Disabled"
-
-        <div class="state-box">
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pd" class="input-field has-value" type="text" value="Input Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="noicon-pd">Label text</label>
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined">
+                    <input
+                    class="input-field error"
+                    type="text"
+                    >
+                    <label class="input-label" for="ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
-        
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon">
-                <input id="noicon-pd" class="input-field has-value" type="text" value="Input Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="noicon-pd">Label text</label>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined">
+                        <input
+                        class="input-field error"
+                        type="text"
+                        >
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled">
+                    <input
+                        id="ue"
+                        class="input-field error"
+                        type="text"
+                    />
+                    <label class="input-label" for="ue">Label</label>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled">
+                        <input
+                            id="ue"
+                            class="input-field error"
+                            type="text"
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined">
+                        <input
+                            id="ue"
+                            class="input-field"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined">
+                        <input
+                            id="ue"
+                            class="input-field"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled">
+                    <input
+                        id="ue"
+                        class="input-field"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="ue">Label</label>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled">
+                        <input
+                            id="ue"
+                            class="input-field"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="ue">Label</label>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
 
 === "Leading Icon"
-    <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-ue" class="input-field with-label" type="text" placeholder="Placeholder" readonly aria-label="Leading icon unpopulated enabled input">
-                <label class="input-label" for="leading-ue">Label Text</label>
-            </div>
-        </div>
-
-    <h2 class="no-toc">States</h2>
-
-    === "Unpopulated/Enabled"
+    <div data-theme>
         <div class="state-box">
-            <div class="input-wrapper leading-icon">
+            <div class="input-wrapper input-filled leading-icon">
                 <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="11" cy="11" r="7"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <line x1="16.65" y1="16.65" x2="21" y2="21"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
-                <input id="leading-ue" class="input-field with-label" type="text" placeholder="Placeholder" readonly aria-label="Leading icon unpopulated enabled input">
-                <label class="input-label" for="leading-ue">Label Text</label>
+                <input
+                    id="ls-ue"
+                    class="input-field leading-icon"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="ls-ue">Label</label>
             </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-ue" class="input-field with-label" type="text" placeholder="Placeholder" readonly aria-label="Leading icon unpopulated enabled input">
-                <label class="input-label" for="leading-ue">Label Text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pe" class="input-field has-value leading-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="leading-pe">Label text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pe" class="input-field has-value leading-icon" type="text" value="Label Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="leading-pe">Label</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Unpopulated/Hovered"
-
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-uh" class="input-field with-label is-hover leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="leading-uh">Label Text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-uh" class="input-field with-label is-hover leading-icon" type="text" aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="leading-uh">Label Text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-ph" class="input-field has-value is-hover leading-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="leading-ph">Label text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-ph" class="input-field has-value is-hover leading-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="leading-ph">Label text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-uf" class="input-field with-label is-focused leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="leading-uf">Label text</label>  
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-uf" class="input-field with-label is-focused leading-icon" type="text" aria-label="Unpopulated focused input field">
-                <label class="input-label" for="leading-uf">Label text</label>  
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pf" class="input-field has-value is-focused leading-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="leading-pf">Label text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pf" class="input-field has-value is-focused leading-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="leading-pf">Label text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-uee" class="input-field error with-label leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="leading-uee">Label Text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-uee" class="input-field error with-label leading-icon" type="text" aria-label="Unpopulated error input field">
-                <label class="input-label" for="leading-uee">Label Text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pee" class="input-field error has-value leading-icon" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="leading-pee">Label text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pee" class="input-field error has-value leading-icon" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="leading-pee">Label text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Unpopulated/Disabled"
-
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-ud" class="input-field with-label leading-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="leading-ud">Label</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-ud" class="input-field with-label leading-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="leading-ud">Label</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pd" class="input-field has-value leading-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="leading-pd">Label Text</label>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-pd" class="input-field has-value leading-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="leading-pd">Label Text</label>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon"
-            ```
-
-
-=== "Trailing Icon"
-    <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ue" class="input-field with-label trailing-icon" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="trailing-ue">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-    <h2 class="no-toc">States</h2>
-
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ue" class="input-field with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="trailing-ue">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ue" class="input-field with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="trailing-ue">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pe" class="input-field has-value trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="trailing-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pe" class="input-field has-value trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="trailing-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-uh" class="input-field with-label is-hover trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="trailing-uh">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-uh" class="input-field with-label is-hover trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="trailing-uh">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ph" class="input-field has-value is-hover trailing-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="trailing-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ph" class="input-field has-value is-hover trailing-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="trailing-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-uf" class="input-field with-label is-focused trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="trailing-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-uf" class="input-field with-label is-focused trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="trailing-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pf" class="input-field has-value is-focused trailing-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="trailing-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pf" class="input-field has-value is-focused trailing-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="trailing-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-uee" class="input-field error with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="trailing-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-uee" class="input-field error with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="trailing-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pee" class="input-field error has-value trailing-icon" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="trailing-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pee" class="input-field error has-value trailing-icon" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="trailing-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Unpopulated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ud" class="input-field with-label trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="trailing-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-ud" class="input-field with-label trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="trailing-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pd" class="input-field has-value trailing-icon" type="text" value="Input Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="trailing-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon">
-                <input id="trailing-pd" class="input-field has-value trailing-icon" type="text" value="Example Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="trailing-pd">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon"
-            ```
-
-
-=== "No Icon + Supp. Text"
-    <div class="state-box">
-        <div class="input-wrapper no-icon-supporting">
-            <input id="noicon-support-ue" class="input-field with-label" type="text" aria-label="Unpopulated enabled input field">
-            <label class="input-label" for="noicon-support-ue">Label Text</label>
-            <p class="input-helper">Supporting text</p>
         </div>
     </div>
 
     <h2 class="no-toc">States</h2>
 
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-ue" class="input-field with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="noicon-support-ue">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="ls-ue"
+                        class="input-field leading-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-ue" class="input-field with-label" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="noicon-support-ue">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="ls-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pe" class="input-field has-value" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="noicon-support-pe">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="ls-ue"
+                        class="input-field leading-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pe" class="input-field has-value" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="noicon-support-pe">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="ls-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-uh" class="input-field with-label is-hover" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="noicon-support-uh">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-uh" class="input-field with-label is-hover" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="noicon-support-uh">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-ph" class="input-field has-value is-hover" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="noicon-support-ph">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="ls-ue"
+                        class="input-field leading-icon is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-ph" class="input-field has-value is-hover" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="noicon-support-ph">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="ls-ue"
+                            class="input-field leading-icon is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-uf" class="input-field with-label is-focused" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="noicon-support-uf">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-uf" class="input-field with-label is-focused" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="noicon-support-uf">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Focused"
+
+=== "Trailing Icon"
+    <div data-theme>
         <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pf" class="input-field has-value is-focused" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="noicon-support-pf">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div class="input-wrapper input-filled trailing-icon">
+                <input
+                    id="ts-ue"
+                    class="input-field trailing-icon"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="lts-ue">Label</label>
+                <span class="input-icon trailing" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="10"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <path d="M9 9L15 15M15 9L9 15"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
+                    </svg>
+                </span>
+            </div>
+        </div>
+    </div>
+
+    <h2 class="no-toc">States</h2>
+
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pf" class="input-field has-value is-focused" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="noicon-support-pf">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-uee" class="input-field error with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="noicon-support-uee">Label Text</label>
-                <p class="input-helper error">Supporting text</p>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-uee" class="input-field error with-label" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="noicon-support-uee">Label Text</label>
-                <p class="input-helper error">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pee" class="input-field error has-value" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="noicon-support-pee">Label text</label>
-                <p class="input-helper error">Supporting Text</p>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon">
+                    <input
+                    class="input-field trailing-icon is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pee" class="input-field error has-value" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="noicon-support-pee">Label text</label>
-                <p class="input-helper error">Supporting Text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon">
+                        <input
+                        class="input-field trailing-icon is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-ud" class="input-field with-label" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="noicon-support-ud">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-ud" class="input-field with-label" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="noicon-support-ud">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon">
+                        <input
+                            id="lts-ue"
+                            class="input-field trailing-icon is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pd" class="input-field has-value" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="noicon-support-pd">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon">
+                    <input
+                    class="input-field trailing-icon is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper no-icon-supporting">
-                <input id="noicon-support-pd" class="input-field has-value" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="noicon-support-pd">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon">
+                        <input
+                        class="input-field trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:no-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
+
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon">
+                        <input
+                            id="lts-ue"
+                            class="input-field trailing-icon is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon">
+                    <input
+                    class="input-field trailing-icon error"
+                    type="text"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle cx="12" cy="12" r="10" fill="currentColor"/>
+                            <rect x="11" y="6" width="2" height="8" fill="#fff" rx="1"/>
+                            <circle cx="12" cy="17" r="1.2" fill="#fff"/>
+                        </svg>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon">
+                        <input
+                        class="input-field trailing-icon error"
+                        type="text"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle cx="12" cy="12" r="10" fill="currentColor"/>
+                                <rect x="11" y="6" width="2" height="8" fill="#fff" rx="1"/>
+                                <circle cx="12" cy="17" r="1.2" fill="#fff"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon">
+                    <input
+                        id="lts-ue"
+                        class="input-field trailing-icon error"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle cx="12" cy="12" r="10" fill="currentColor"/>
+                            <rect x="11" y="6" width="2" height="8" fill="#fff" rx="1"/>
+                            <circle cx="12" cy="17" r="1.2" fill="#fff"/>
+                        </svg>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon">
+                        <input
+                            id="lts-ue"
+                            class="input-field trailing-icon error"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle cx="12" cy="12" r="10" fill="currentColor"/>
+                                <rect x="11" y="6" width="2" height="8" fill="#fff" rx="1"/>
+                                <circle cx="12" cy="17" r="1.2" fill="#fff"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+=== "No Icon + Supp. Text"
+    <div data-theme>
+        <div class="state-box">
+            <div class="input-wrapper input-filled has-supporting">
+                <input
+                    id="s-ue"
+                    class="input-field"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="ls-ue">Label</label>
+                <p class="input-helper">Supporting text</p>
+            </div>
+        </div>
+    </div>
+
+    <h2 class="no-toc">States</h2>
+
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined has-supporting">
+                    <input
+                        id="ls-ue"
+                        class="input-field"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled has-supporting">
+                    <input
+                        id="lts-ue"
+                        class="input-field"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled has-supporting">
+                        <input
+                            id="ls-ue"
+                            class="input-field"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined has-supporting">
+                    <input
+                    class="input-field is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined has-supporting">
+                        <input
+                        class="input-field is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled has-supporting">
+                    <input
+                        id="lts-ue"
+                        class="input-field is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined has-supporting">
+                    <input
+                    class="input-field is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined has-supporting">
+                        <input
+                        class="input-field is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled has-supporting">
+                    <input
+                        id="ls-ue"
+                        class="input-field is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined has-supporting">
+                    <input
+                    class="input-field error"
+                    type="text"
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined has-supporting">
+                        <input
+                        class="input-field error"
+                        type="text"
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled has-supporting">
+                    <input
+                        id="lts-ue"
+                        class="input-field error"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field error"
+                            type="text"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined has-supporting">
+                        <input
+                            id="ls-ue"
+                            class="input-field"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled has-supporting">
+                    <input
+                        id="lts-ue"
+                        class="input-field"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
+            </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+    
 
 
 === "Leading Icon + Supp. Text"
-    <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
+    <div data-theme>
+        <div class="state-box">
+            <div class="input-wrapper input-filled leading-icon has-supporting">
                 <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="11" cy="11" r="7"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <line x1="16.65" y1="16.65" x2="21" y2="21"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
-                <input id="leading-support-ue" class="input-field with-label leading-icon" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="leading-support-ue">Label Text</label>
+                <input
+                    id="ls-ue"
+                    class="input-field leading-icon"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="ls-ue">Label</label>
                 <p class="input-helper">Supporting text</p>
             </div>
         </div>
-    
+    </div>
+
     <h2 class="no-toc">States</h2>
 
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-ue" class="input-field with-label leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="leading-support-ue">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="ls-ue"
+                        class="input-field leading-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-ue" class="input-field with-label leading-icon" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="leading-support-ue">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pe" class="input-field has-value leading-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="leading-support-pe">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pe" class="input-field has-value leading-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="leading-support-pe">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="ls-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-uh" class="input-field with-label is-hover leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="leading-support-uh">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-uh" class="input-field with-label is-hover leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="leading-support-uh">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-ph" class="input-field has-value is-hover leading-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="leading-support-ph">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-ph" class="input-field has-value is-hover leading-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="leading-support-ph">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-uf" class="input-field with-label is-focused leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="leading-support-uf">Label Text</label>
-                <p class="input-helper">Supporting text</p>
-            </div>
-        </div>
-
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-uf" class="input-field with-label is-focused leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="leading-support-uf">Label Text</label>
-                <p class="input-helper">Supporting text</p>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
-            ```
-
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pf" class="input-field has-value is-focused leading-icon" type="text" value="Label Text" aria-label="Populated focused input field">
-                <label class="input-label" for="leading-support-pf">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pf" class="input-field has-value is-focused leading-icon" type="text" value="Label Text" aria-label="Populated focused input field">
-                <label class="input-label" for="leading-support-pf">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-uee" class="input-field error with-label leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="leading-support-uee">Label Text</label>
-                <p class="input-helper error">Supporting text</p>
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="ls-ue"
+                        class="input-field leading-icon is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-uee" class="input-field error with-label leading-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="leading-support-uee">Label Text</label>
-                <p class="input-helper error">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pee" class="input-field error has-value leading-icon" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="leading-support-pee">Label text</label>
-                <p class="input-helper error">Supporting text</p>
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon error"
+                    type="text"
+                    >
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pee" class="input-field error has-value leading-icon" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="leading-support-pee">Label text</label>
-                <p class="input-helper error">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon error"
+                        type="text"
+                        >
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-ud" class="input-field with-label leading-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="leading-support-ud">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon error"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="stroke="#9D9F9F"" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-ud" class="input-field with-label leading-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="leading-support-ud">Label Text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon error"
+                            type="text"
+                        />
+                        <label class="input-label" for="ls-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pd" class="input-field has-value leading-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="leading-support-pd">Label text</label>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="ls-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="ls-ue">Label</label>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="stroke="#9D9F9F"" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="stroke="#9D9F9F"" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="leading-support-pd" class="input-field has-value leading-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="leading-support-pd">Label text</label>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
 === "Trailing Icon + Supp. Text"
-    <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ue" class="input-field with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="trailing-support-ue">Label Text</label>
+    <div data-theme>
+        <div class="state-box">
+            <div class="input-wrapper input-filled trailing-icon has-supporting">
+                <input
+                    id="ts-ue"
+                    class="input-field trailing-icon"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="lts-ue">Label</label>
                 <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="10"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <path d="M9 9L15 15M15 9L9 15"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
                 <p class="input-helper">Supporting text</p>
             </div>
         </div>
+    </div>
 
     <h2 class="no-toc">States</h2>
 
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ue" class="input-field with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="trailing-support-ue">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ue" class="input-field with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="trailing-support-ue">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                        <input
+                            id="ts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pe" class="input-field has-value trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="trailing-support-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon has-supporting">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pe" class="input-field has-value trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="trailing-support-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon has-supporting">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-uh" class="input-field with-label is-hover trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="trailing-support-uh">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                    <input
+                    class="input-field trailing-icon is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-uh" class="input-field with-label is-hover trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="trailing-support-uh">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                        <input
+                        class="input-field trailing-icon is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ph" class="input-field has-value is-hover trailing-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="trailing-support-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon has-supporting">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ph" class="input-field has-value is-hover trailing-icon" type="text" value="Input Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="trailing-support-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field trailing-icon is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-uf" class="input-field with-label is-focused trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="trailing-support-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                    <input
+                    class="input-field trailing-icon is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-uf" class="input-field with-label is-focused trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="trailing-support-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                        <input
+                        class="input-field trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pf" class="input-field has-value is-focused trailing-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="trailing-support-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon has-supporting">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pf" class="input-field has-value is-focused trailing-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="trailing-support-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field trailing-icon is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-uee" class="input-field error with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="trailing-support-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Supporting text</p>
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                    <input
+                    class="input-field trailing-icon error"
+                    type="text"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="11"
+                                y="6"
+                                width="2"
+                                height="8"
+                                fill="#fff"
+                                rx="1"
+                            />
+                            <circle
+                                cx="12"
+                                cy="17"
+                                r="1.2"
+                                fill="#fff"
+                            />
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-uee" class="input-field error with-label trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="trailing-support-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                        <input
+                        class="input-field trailing-icon error"
+                        type="text"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    fill="currentColor"
+                                />
+                                <rect
+                                    x="11"
+                                    y="6"
+                                    width="2"
+                                    height="8"
+                                    fill="#fff"
+                                    rx="1"
+                                />
+                                <circle
+                                    cx="12"
+                                    cy="17"
+                                    r="1.2"
+                                    fill="#fff"
+                                />
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pee" class="input-field error has-value trailing-icon" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="trailing-support-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Error message here</p>
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon has-supporting">
+                    <input
+                        id="lts-ue"
+                        class="input-field trailing-icon error"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="11"
+                                y="6"
+                                width="2"
+                                height="8"
+                                fill="#fff"
+                                rx="1"
+                            />
+                            <circle
+                                cx="12"
+                                cy="17"
+                                r="1.2"
+                                fill="#fff"
+                            />
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pee" class="input-field error has-value trailing-icon" type="text" value="Input Text" aria-label="Populated error input field">
-                <label class="input-label" for="trailing-support-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Error message here</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon has-supporting">
+                        <input
+                            id="lts-ue"
+                            class="input-field trailing-icon error"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    fill="currentColor"
+                                />
+                                <rect
+                                    x="11"
+                                    y="6"
+                                    width="2"
+                                    height="8"
+                                    fill="#fff"
+                                    rx="1"
+                                />
+                                <circle
+                                    cx="12"
+                                    cy="17"
+                                    r="1.2"
+                                    fill="#fff"
+                                />
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ud" class="input-field with-label trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="trailing-support-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined trailing-icon has-supporting">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled trailing-icon has-supporting">
+                    <input
+                        id="ts-ue"
+                        class="input-field trailing-icon"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-ud" class="input-field with-label trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="trailing-support-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled trailing-icon has-supporting">
+                        <input
+                            id="ts-ue"
+                            class="input-field trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
-
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pd" class="input-field has-value trailing-icon" type="text" value="Input Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="trailing-support-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper trailing-icon-supporting">
-                <input id="trailing-support-pd" class="input-field has-value trailing-icon" type="text" value="Input Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="trailing-support-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:trailing-icon-supporting"
-            ```
-
 
 === "Leading + Trailing Icon"
-    <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
+    <div data-theme>
+        <div class="state-box">
+            <div class="input-wrapper input-filled leading-icon trailing-icon">
                 <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="11" cy="11" r="7"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <line x1="16.65" y1="16.65" x2="21" y2="21"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
-                <input id="lt-ue" class="input-field with-label leading-icon trailing-icon" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="lt-ue">Label</label>
+                <input
+                    id="lts-ue"
+                    class="input-field leading-icon trailing-icon"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
+                <label class="input-label" for="lts-ue">Label</label>
                 <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="10"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <path d="M9 9L15 15M15 9L9 15"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
             </div>
         </div>
+    </div>
 
     <h2 class="no-toc">States</h2>
 
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-ue" class="input-field with-label leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="lt-ue">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-ue" class="input-field with-label leading-icon trailing-icon" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="lt-ue">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
-            ```
-
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pe" class="input-field has-value leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="lt-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pe" class="input-field has-value leading-icon trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="lt-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-uh" class="input-field with-label is-hover leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="lt-uh">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-uh" class="input-field with-label is-hover leading-icon trailing-icon" type="text" aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="lt-uh">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-ph" class="input-field has-value is-hover leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="lt-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-ph" class="input-field has-value is-hover leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="lt-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon trailing-icon is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-uf" class="input-field with-label is-focused leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="lt-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-uf" class="input-field with-label is-focused leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="lt-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pf" class="input-field has-value is-focused leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated focused input field">
-                <label class="input-label" for="lt-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pf" class="input-field has-value is-focused leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated focused input field">
-                <label class="input-label" for="lt-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-uee" class="input-field error with-label leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="lt-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-uee" class="input-field error with-label leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="lt-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pee" class="input-field error has-value leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="lt-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon error"
+                    type="text"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="11"
+                                y="6"
+                                width="2"
+                                height="8"
+                                fill="#fff"
+                                rx="1"
+                            />
+                            <circle
+                                cx="12"
+                                cy="17"
+                                r="1.2"
+                                fill="#fff"
+                            />
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pee" class="input-field error has-value leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="lt-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon trailing-icon error"
+                        type="text"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    fill="currentColor"
+                                />
+                                <rect
+                                    x="11"
+                                    y="6"
+                                    width="2"
+                                    height="8"
+                                    fill="#fff"
+                                    rx="1"
+                                />
+                                <circle
+                                    cx="12"
+                                    cy="17"
+                                    r="1.2"
+                                    fill="#fff"
+                                />
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-ud" class="input-field with-label leading-icon trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="lt-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon error"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="11"
+                                y="6"
+                                width="2"
+                                height="8"
+                                fill="#fff"
+                                rx="1"
+                            />
+                            <circle
+                                cx="12"
+                                cy="17"
+                                r="1.2"
+                                fill="#fff"
+                            />
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-ud" class="input-field with-label leading-icon trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="lt-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon error"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    fill="currentColor"
+                                />
+                                <rect
+                                    x="11"
+                                    y="6"
+                                    width="2"
+                                    height="8"
+                                    fill="#fff"
+                                    rx="1"
+                                />
+                                <circle
+                                    cx="12"
+                                    cy="17"
+                                    r="1.2"
+                                    fill="#fff"
+                                />
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+            </div>
+                ```
+            === "CSS"
+                ```css
+                --8<-- "components/sass/components/_input-fields.scss:input"
+                ```
+
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pd" class="input-field has-value leading-icon trailing-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="lt-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lt-pd" class="input-field has-value leading-icon trailing-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="lt-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
-
 
 === "Leading + Trailing Icon + Supporting Text"
-    <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
+    <div data-theme>
+        <div class="state-box">
+            <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
                 <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="11" cy="11" r="7"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <line x1="16.65" y1="16.65" x2="21" y2="21"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
-                <input id="lts-ue" class="input-field with-label leading-icon trailing-icon" type="text" aria-label="Unpopulated enabled input field">
+                <input
+                    id="lts-ue"
+                    class="input-field leading-icon trailing-icon"
+                    type="text"
+                    aria-label="Unpopulated enabled input field"
+                />
                 <label class="input-label" for="lts-ue">Label</label>
                 <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <svg viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="10"
+                                stroke="currentColor"
+                                stroke-width="2"/>
+                        <path d="M9 9L15 15M15 9L9 15"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"/>
                     </svg>
                 </span>
                 <p class="input-helper">Supporting text</p>
             </div>
         </div>
+    </div>
 
     <h2 class="no-toc">States</h2>
 
-    === "Unpopulated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-ue" class="input-field with-label leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="lts-ue">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-ue" class="input-field with-label leading-icon trailing-icon" type="text" aria-label="Unpopulated enabled input field">
-                <label class="input-label" for="lts-ue">Label</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Enabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pe" class="input-field has-value leading-icon trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="lts-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Enabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon"
+                        type="text"
+                        aria-label="Unpopulated enabled input field"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pe" class="input-field has-value leading-icon trailing-icon" type="text" value="Input Text" aria-label="Populated enabled input field">
-                <label class="input-label" for="lts-pe">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            aria-label="Unpopulated enabled input field"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-uh" class="input-field with-label is-hover leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="lts-uh">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon is-hover"
+                    type="text"
+                    aria-label="Hovered input"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-uh" class="input-field with-label is-hover leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated hovered input field">
-                <label class="input-label" for="lts-uh">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon trailing-icon is-hover"
+                        type="text"
+                        aria-label="Hovered input"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Hovered"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-ph" class="input-field has-value is-hover leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="lts-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Hovered"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon is-hover"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-ph" class="input-field has-value is-hover leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated hovered input field">
-                <label class="input-label" for="lts-ph">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon is-hover"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-uf" class="input-field with-label is-focused leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="lts-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon is-focus"
+                    type="text"
+                    autofocus
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-uf" class="input-field with-label is-focused leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated focused input field">
-                <label class="input-label" for="lts-uf">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Focused"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pf" class="input-field has-value is-focused leading-icon trailing-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="lts-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Filled/Focused"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon is-focus"
+                        type="text"
+                        autofocus
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pf" class="input-field has-value is-focused leading-icon trailing-icon" type="text" value="Input Text" aria-label="Populated focused input field">
-                <label class="input-label" for="lts-pf">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon is-focus"
+                            type="text"
+                            autofocus
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-uee" class="input-field error with-label leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="lts-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Supporting text</p>
+    === "Outlined/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                    class="input-field leading-icon trailing-icon error"
+                    type="text"
+                    >
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="11"
+                                y="6"
+                                width="2"
+                                height="8"
+                                fill="#fff"
+                                rx="1"
+                            />
+                            <circle
+                                cx="12"
+                                cy="17"
+                                r="1.2"
+                                fill="#fff"
+                            />
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-uee" class="input-field error with-label leading-icon trailing-icon" type="text" placeholder="Placeholder" readonly aria-label="Unpopulated error input field">
-                <label class="input-label" for="lts-uee">Label Text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                        class="input-field leading-icon trailing-icon error"
+                        type="text"
+                        >
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    fill="currentColor"
+                                />
+                                <rect
+                                    x="11"
+                                    y="6"
+                                    width="2"
+                                    height="8"
+                                    fill="#fff"
+                                    rx="1"
+                                />
+                                <circle
+                                    cx="12"
+                                    cy="17"
+                                    r="1.2"
+                                    fill="#fff"
+                                />
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Populated/Error"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pee" class="input-field error has-value leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="lts-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Supporting text</p>
+    === "Filled/Error"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon error"
+                        type="text"
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24">
+                            <circle
+                                cx="12"
+                                cy="12"
+                                r="10"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="11"
+                                y="6"
+                                width="2"
+                                height="8"
+                                fill="#fff"
+                                rx="1"
+                            />
+                            <circle
+                                cx="12"
+                                cy="17"
+                                r="1.2"
+                                fill="#fff"
+                            />
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#000000" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#000000" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pee" class="input-field error has-value leading-icon trailing-icon" type="text" value="Label Text" aria-label="Populated error input field">
-                <label class="input-label" for="lts-pee">Label text</label>
-                <span class="input-icon trailing error" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" fill="#D32F2F"/>
-                        <path d="M12 7V13" stroke="white" stroke-width="2" stroke-linecap="round"/>
-                        <circle cx="12" cy="17" r="1.5" fill="white"/>
-                    </svg>
-                </span>
-                <p class="input-helper error">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon error"
+                            type="text"
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24">
+                                <circle
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    fill="currentColor"
+                                />
+                                <rect
+                                    x="11"
+                                    y="6"
+                                    width="2"
+                                    height="8"
+                                    fill="#fff"
+                                    rx="1"
+                                />
+                                <circle
+                                    cx="12"
+                                    cy="17"
+                                    r="1.2"
+                                    fill="#fff"
+                                />
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
-    === "Unpopulated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-ud" class="input-field with-label leading-icon trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="lts-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+    === "Outlined/Disabled"
+        <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+        </div>
+
+        <h2 class="no-toc">Code</h2>
+        === "HTML"
+            ```html
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-outlined leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
+            </div>
+            ```
+        === "CSS"
+            ```css
+            --8<-- "components/sass/components/_input-fields.scss:input"
+            ```
+
+    === "Filled/Disabled"
+        <div data-theme>
+            <div class="state-box">
+                <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                    <span class="input-icon leading" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="11" cy="11" r="7"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <input
+                        id="lts-ue"
+                        class="input-field leading-icon trailing-icon"
+                        type="text"
+                        disabled
+                    />
+                    <label class="input-label" for="lts-ue">Label</label>
+                    <span class="input-icon trailing" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none">
+                            <circle cx="12" cy="12" r="10"
+                                    stroke="currentColor"
+                                    stroke-width="2"/>
+                            <path d="M9 9L15 15M15 9L9 15"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"/>
+                        </svg>
+                    </span>
+                    <p class="input-helper">Supporting text</p>
+                </div>
             </div>
         </div>
 
         <h2 class="no-toc">Code</h2>
         === "HTML"
             ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-ud" class="input-field with-label leading-icon trailing-icon" type="text" disabled aria-label="Unpopulated disabled input field">
-                <label class="input-label" for="lts-ud">Label Text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
+            <div data-theme>
+                <div class="state-box">
+                    <div class="input-wrapper input-filled leading-icon trailing-icon has-supporting">
+                        <span class="input-icon leading">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="11" cy="11" r="7"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <line x1="16.65" y1="16.65" x2="21" y2="21"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <input
+                            id="lts-ue"
+                            class="input-field leading-icon trailing-icon"
+                            type="text"
+                            disabled
+                        />
+                        <label class="input-label" for="lts-ue">Label</label>
+                        <span class="input-icon trailing" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none">
+                                <circle cx="12" cy="12" r="10"
+                                        stroke="currentColor"
+                                        stroke-width="2"/>
+                                <path d="M9 9L15 15M15 9L9 15"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    stroke-linecap="round"/>
+                            </svg>
+                        </span>
+                        <p class="input-helper">Supporting text</p>
+                    </div>
+                </div>
             </div>
             ```
         === "CSS"
             ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
-            ```
-
-    === "Populated/Disabled"
-        <div class="state-box">
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pd" class="input-field has-value leading-icon trailing-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="lts-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
-            </div>
-        </div>
-
-        <h2 class="no-toc">Code</h2>
-        === "HTML"
-            ```html
-            <div class="input-wrapper leading-trailing-icon-supporting">
-                <span class="input-icon leading">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="11" cy="11" r="7" stroke="#9D9F9F" stroke-width="2"/>
-                        <line x1="16.65" y1="16.65" x2="21" y2="21" stroke="#9D9F9F" stroke-width="2"/>
-                    </svg>
-                </span>
-                <input id="lts-pd" class="input-field has-value leading-icon trailing-icon" type="text" value="Label Text" disabled aria-label="Populated disabled input field">
-                <label class="input-label" for="lts-pd">Label text</label>
-                <span class="input-icon trailing" aria-hidden="true">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2"/>
-                        <path d="M9 9L15 15M15 9L9 15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                    </svg>
-                </span>
-                <p class="input-helper">Supporting text</p>
-            </div>
-            ```
-        === "CSS"
-            ```css
-            --8<-- "components/sass/components/_input-fields.scss:leading-trailing-icon-supporting"
+            --8<-- "components/sass/components/_input-fields.scss:input"
             ```
 
 
 ---
-
-## **Resources**
-- [SASS file on GitHub](https://github.com/hackforla/internship-website-design-system/blob/main/docs/components/sass/components/_input-fields.scss)
-- [Markdown file on GitHub](https://github.com/hackforla/internship-website-design-system/blob/main/docs/input-fields.md)


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #818
https://github.com/orgs/hackforla/projects/64/views/4?pane=issue&itemId=160076706&issue=hackforla%7Cinternship%7C818

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Implemented Material 3 compliant input field components across variants (no icon, leading/trailing icon, supporting text)
  - Added state handling for input fields (enabled, hovered, focused, populated, error, disabled)
  - Integrated design tokens for styling (colors, typography, spacing, borders) to ensure consistency with the design system

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - To align input field components with Material 3 design specifications
  - To standardize component behavior and states across the design system
  - To enable scalable and maintainable styling using token-based architecture

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)

<details>
<summary>Visuals before changes are applied</summary>
<img width="771" height="796" alt="Screenshot 2026-03-18 at 9 29 52 AM" src="https://github.com/user-attachments/assets/b1ad6d4f-f503-414e-a580-eb733fe39b0c" />


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="770" height="832" alt="Screenshot 2026-03-18 at 9 30 08 AM" src="https://github.com/user-attachments/assets/bdbf1d96-ad79-4712-aa63-3c5ea450c250" />


</details>