### PR TITLE
Microsite Issue #552

### DIFF
--- a/docs/components/sass/components/_microsite.scss
+++ b/docs/components/sass/components/_microsite.scss
@@ -1,0 +1,121 @@
+[data-md-color-scheme] {
+
+  .md-sidebar--primary {
+    border-right: none;
+    --md-typeset-a-color: var(--token-on-surface, #1c1b1f);
+    --md-accent-fg-color: var(--token-on-surface, #1c1b1f);
+  }
+
+  .md-sidebar--primary .md-sidebar__inner {
+    padding: 16px 12px;
+  }
+
+  /* Reset nav spacing */
+  .md-sidebar--primary .md-nav,
+  .md-sidebar--primary .md-nav__list,
+  .md-sidebar--primary .md-nav__item {
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Remove Material decorative title markers */
+  .md-sidebar--primary .md-nav__title::before,
+  .md-sidebar--primary .md-nav__title::after {
+    display: none;
+    content: none;
+  }
+
+  /* Hide duplicate nested back/title rows */
+  .md-sidebar--primary .md-nav .md-nav__title {
+    display: none;
+  }
+
+  /* Hide TOC toggle label that duplicates the page title when active */
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link--active {
+    display: none !important;
+  }
+
+  /* Hide inline TOC nav inside leaf items (Getting Started, FAQ) — TOC belongs in secondary sidebar */
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item:not(.md-nav__item--nested) > .md-nav {
+    display: none !important;
+  }
+
+  /* ── Top-level items: Getting Started, FAQ (a), Styles, Components (label) ── */
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link,
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link {
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 0 16px;
+    margin: 0;
+    font-size: 16px !important;
+    font-weight: 600 !important;
+    color: var(--token-on-surface, #1c1b1f) !important;
+    text-decoration: none;
+    background: transparent !important;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  /* No hover background on top-level items */
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link:hover,
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link:focus,
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link:hover,
+  .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link:focus {
+    background-color: transparent !important;
+    color: var(--token-on-surface, #1c1b1f) !important;
+  }
+
+  /* ── Child leaf links: Accordion, Buttons, Typography, etc. ── */
+  .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link {
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    padding: 0 16px 0 18px;
+    margin: 0;
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--token-on-surface-variant, #49454f) !important;
+    text-decoration: none;
+    background: transparent !important;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:visited {
+    color: var(--token-on-surface-variant, #49454f) !important;
+  }
+
+  /* Hover only for child links */
+  .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:hover,
+  .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:focus {
+    background-color: #d9e8eb !important;
+    color: var(--token-on-surface, #1c1b1f) !important;
+    box-shadow: none;
+    text-decoration: none;
+  }
+
+  /* Active page highlight */
+  .md-sidebar--primary a.md-nav__link--active,
+  .md-sidebar--primary .md-nav__item--active > a.md-nav__link,
+  .md-sidebar--primary a.md-nav__link--active:visited,
+  .md-sidebar--primary a.md-nav__link--active:hover,
+  .md-sidebar--primary a.md-nav__link--active:focus {
+    background-color: #b7d3d9 !important;
+    color: var(--token-on-surface, #1c1b1f) !important;
+    font-weight: 600;
+    box-shadow: none;
+    border: 0;
+  }
+
+  /* Arrow icon */
+  .md-sidebar--primary .md-nav__icon {
+    color: var(--token-on-surface, #1c1b1f) !important;
+    opacity: 1;
+  }
+}
+

--- a/docs/components/sass/main.scss
+++ b/docs/components/sass/main.scss
@@ -17,5 +17,6 @@
 @use 'components/pagination';
 @use 'components/checkbox';
 @use 'components/chips';
+@use 'components/microsite';
 
 @use 'layout/grid';

--- a/docs/dist/main.css
+++ b/docs/dist/main.css
@@ -49,7 +49,6 @@
   --radio-disabled-stroke: gray;
   --radio-button-size: 2.125rem;
   --dropdown-divider-color: #C6C6C6;
-  --dropdown-divider-color: #C6C6C6;
   --tab-text-color: #0D5761;
   --tab-underline-color: #0D5761;
   --tab-hover-color: #0D5761;
@@ -1838,6 +1837,133 @@ label {
 .chip-avatar-trailing .icon.-trailing {
   --md-icon-size: var(--token-chip-icon-size);
   color: var(--token-chip-color-icon-secondary);
+}
+
+[data-md-color-scheme] .md-sidebar--primary {
+  border-right: none;
+  --md-typeset-a-color: var(--token-on-surface, #1c1b1f);
+  --md-accent-fg-color: var(--token-on-surface, #1c1b1f);
+}
+[data-md-color-scheme] .md-sidebar--primary .md-sidebar__inner {
+  padding: 16px 12px;
+}
+[data-md-color-scheme] {
+  /* Reset nav spacing */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav,
+[data-md-color-scheme] .md-sidebar--primary .md-nav__list,
+[data-md-color-scheme] .md-sidebar--primary .md-nav__item {
+  margin: 0;
+  padding: 0;
+}
+[data-md-color-scheme] {
+  /* Remove Material decorative title markers */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav__title::before,
+[data-md-color-scheme] .md-sidebar--primary .md-nav__title::after {
+  display: none;
+  content: none;
+}
+[data-md-color-scheme] {
+  /* Hide duplicate nested back/title rows */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav .md-nav__title {
+  display: none;
+}
+[data-md-color-scheme] {
+  /* Hide TOC toggle label that duplicates the page title when active */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link--active {
+  display: none !important;
+}
+[data-md-color-scheme] {
+  /* Hide inline TOC nav inside leaf items (Getting Started, FAQ) — TOC belongs in secondary sidebar */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item:not(.md-nav__item--nested) > .md-nav {
+  display: none !important;
+}
+[data-md-color-scheme] {
+  /* ── Top-level items: Getting Started, FAQ (a), Styles, Components (label) ── */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link,
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 0 16px;
+  margin: 0;
+  font-size: 16px !important;
+  font-weight: 600 !important;
+  color: var(--token-on-surface, #1c1b1f) !important;
+  text-decoration: none;
+  background: transparent !important;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+[data-md-color-scheme] {
+  /* No hover background on top-level items */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link:hover,
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link:focus,
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link:hover,
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link:focus {
+  background-color: transparent !important;
+  color: var(--token-on-surface, #1c1b1f) !important;
+}
+[data-md-color-scheme] {
+  /* ── Child leaf links: Accordion, Buttons, Typography, etc. ── */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 0 16px 0 18px;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--token-on-surface-variant, #49454f) !important;
+  text-decoration: none;
+  background: transparent !important;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:visited {
+  color: var(--token-on-surface-variant, #49454f) !important;
+}
+[data-md-color-scheme] {
+  /* Hover only for child links */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:hover,
+[data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:focus {
+  background-color: #d9e8eb !important;
+  color: var(--token-on-surface, #1c1b1f) !important;
+  box-shadow: none;
+  text-decoration: none;
+}
+[data-md-color-scheme] {
+  /* Active page highlight */
+}
+[data-md-color-scheme] .md-sidebar--primary a.md-nav__link--active,
+[data-md-color-scheme] .md-sidebar--primary .md-nav__item--active > a.md-nav__link,
+[data-md-color-scheme] .md-sidebar--primary a.md-nav__link--active:visited,
+[data-md-color-scheme] .md-sidebar--primary a.md-nav__link--active:hover,
+[data-md-color-scheme] .md-sidebar--primary a.md-nav__link--active:focus {
+  background-color: #b7d3d9 !important;
+  color: var(--token-on-surface, #1c1b1f) !important;
+  font-weight: 600;
+  box-shadow: none;
+  border: 0;
+}
+[data-md-color-scheme] {
+  /* Arrow icon */
+}
+[data-md-color-scheme] .md-sidebar--primary .md-nav__icon {
+  color: var(--token-on-surface, #1c1b1f) !important;
+  opacity: 1;
 }
 
 /* --------------------------------------------------------------------------

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,32 +1,3 @@
-/* Nav Bar Formatting */
-
-.md-nav__item a {
-  height: 2.1rem;
-  line-height: 2rem;
-  text-align: center;
-}
-
-.md-nav__link a {
-  text-align: center;
-  padding-left: 20%;
-}
-
-.md-nav__link {
-  margin-bottom: 10px;
-}
-
-.md-nav__item a:hover,
-.md-nav__link span:hover,
-.md-nav__link:hover,
-.md-nav__link--active {
-  color: blue !important;
-  font-weight: bold;
-}
-
-.md-nav__list {
-  width: 15vw;
-}
-
 /* Tabs hover underline */
 li.md-tabs__item:hover {
   box-shadow: inset 0 -3px 0 0 rgb(123, 178, 162);
@@ -125,4 +96,35 @@ li.md-tabs__item:hover {
 .state-box {
   margin-top: 0 !important;
   margin-bottom: 16px; /* keep just a little breathing room */
+}
+
+/* Show the sidebar expand/collapse arrows */
+.md-sidebar--primary .md-nav__icon {
+  visibility: visible !important;
+  opacity: 1;
+  transition: transform 0.2s ease;
+}
+
+/* Closed state */
+.md-sidebar--primary .md-nav__toggle ~ .md-nav__link .md-nav__icon {
+  transform: rotate(0deg);
+}
+
+/* Open state */
+.md-sidebar--primary .md-nav__toggle:checked ~ .md-nav__link .md-nav__icon {
+  transform: rotate(180deg);
+}
+
+.md-header__inner {
+  min-height: 3rem;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.md-search__form,
+.md-source {
+  height: 2rem;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_url: https://hackforla.github.io/internship-website-design-system/
 nav:
   - Getting Started: index.md
   - Styles:
-      - Typography: type-scale.md
+    - Typography: type-scale.md
   - Components:
     - Accordion: accordion.md
     - Buttons: buttons.md
@@ -18,7 +18,6 @@ nav:
     - Toggles: toggles.md
     - Chips: chips.md
     - Dropdown: dropdowns.md
-   
 
 plugins:
   - search:


### PR DESCRIPTION

Fixes #552
https://github.com/hackforla/internship/issues/552

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - Researched and aligned the microsite approach across related issues and dependencies before implementation, including reviewing prior work and identifying what was already completed vs. what still needed to be updated.
  - Implemented custom microsite sidebar styling in `docs/components/sass/components/_microsite.scss` and added it through the main Sass import so the microsite menu structure matches the intended design system layout.
  - Cleaned up conflicting older navigation styles in `docs/stylesheets/extra.css`, fixed duplicate/incorrect Material nav behavior, and completed the issue implementation; PR has been raised.

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - This issue was not a straightforward standalone component task. The microsite page functions more like a structural layout pattern, so I first needed to confirm what content and behavior it should include before coding.
  - There were multiple existing dependencies and prior implementations tied to this work, so alignment was necessary to determine how closely the final result should follow Material behavior versus the current Design System patterns.
  - The code changes were made to resolve inconsistent navigation behavior caused by Material’s default rendering and older conflicting CSS, so testing should focus on sidebar structure, active states, duplicate nav entries, spacing consistency, and overall microsite navigation behavior.

<details>
<summary>Visuals before changes are applied</summary>
<img width="1185" height="936" alt="Screenshot 2026-04-28 at 4 29 26 PM" src="https://github.com/user-attachments/assets/c278c068-dc04-412f-9753-a4f8deafcf93" />

</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1157" height="878" alt="Screenshot 2026-04-28 at 4 24 44 PM" src="https://github.com/user-attachments/assets/857914ff-0e7f-45eb-a221-102e311b242d" />

</details>
