### PR TITLE
GitHub #552 - Fix responsive nav, header, and mobile UI issues

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<style>
+  /* Widen page grid */
+  .md-grid {
+    max-width: 80rem !important;
+  }
+
+  /* Remove gap between search and GitHub icons */
+  [dir=ltr] .md-header__source {
+    margin-left: 0 !important;
+  }
+</style>
+{% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,14 +3,17 @@ li.md-tabs__item:hover {
   box-shadow: inset 0 -3px 0 0 rgb(123, 178, 162);
 }
 
-/* Hide most icons, except clipboard */
+/* Hide most icons, except clipboard and header buttons (hamburger, search toggle) */
 .md-icon {
   visibility: hidden;
 }
 
-.md-clipboard.md-icon {
+.md-clipboard.md-icon,
+.md-header__button.md-icon,
+.md-source__icon.md-icon {
   visibility: visible !important;
 }
+
 
 /* Active nav link color */
 .md-nav__item .md-nav__link--active {
@@ -121,10 +124,110 @@ li.md-tabs__item:hover {
   gap: 0.5rem;
 }
 
-.md-search__form,
-.md-source {
+.md-search__form {
   height: 2rem;
   border-radius: 999px;
   display: flex;
   align-items: center;
+}
+
+/* GitHub source — never shrink, always show fully */
+.md-header__source {
+  flex-shrink: 0;
+}
+
+.md-source {
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.md-source__repository {
+  overflow: visible;
+  max-width: none;
+}
+
+/* Below ~960px: collapse GitHub to icon only */
+@media screen and (max-width: 60em) {
+  .md-source__repository {
+    display: none !important;
+  }
+}
+
+
+/* Show back-arrows and expand chevrons inside the mobile drawer */
+.md-nav--primary .md-nav__icon {
+  visibility: visible !important;
+}
+
+/* Keep GitHub button in the header on mobile, remove it from the drawer */
+@media screen and (max-width: 76.1875em) {
+  .md-header__source {
+    display: flex !important;
+  }
+  .md-nav--primary .md-source {
+    display: none !important;
+  }
+}
+
+/* ── Mobile drawer back button fix ── */
+@media screen and (max-width: 76.1875em) {
+  /* Reveal the "< Section Name" back button in sub-navs */
+  .md-nav__item--nested > .md-nav > .md-nav__title {
+    display: block !important;
+  }
+
+  /* Reveal the left-arrow icon inside the back button */
+  .md-nav--primary .md-nav__title .md-nav__icon {
+    display: block !important;
+    visibility: visible !important;
+  }
+}
+/* Hide duplicate active-page TOC label in mobile drawer */
+@media screen and (max-width: 76.1875em) {
+  .md-nav--primary .md-nav__item--active > label.md-nav__link--active {
+    display: none !important;
+  }
+  .md-nav--primary .md-nav--secondary {
+    display: none !important;
+  }
+}
+
+@media screen and (max-width: 60em) {
+  .md-source__repository {
+    display: none !important;
+  }
+
+  .md-source {
+    min-width: 0;
+    padding: 0 0.4rem;
+  }
+
+  .md-source__icon {
+    margin: 0;
+  }
+}
+
+/* Tighten gap between search icon and GitHub icon */
+[dir=ltr] .md-header__source {
+  margin-left: 0.5rem !important;
+}
+
+/* Use more of the page width */
+.md-grid {
+  max-width: 80rem !important;
+}
+
+/* Collapse the search form container on mobile so it doesn't gap search icon from GitHub */
+@media screen and (max-width: 76.1875em) {
+  .md-search {
+    width: 0;
+    overflow: visible;
+  }
+}
+
+/* Search back arrow (shown when search is active) */
+.md-search__icon.md-icon {
+  visibility: visible !important;
 }


### PR DESCRIPTION
Fixes #552 
https://github.com/hackforla/internship/issues/552

### What changes did you make?
<!-- Note: add lines if needed, and remove any unused lines -->  
- Added hamburger ☰ menu button visibility on narrow viewports — was hidden by a blanket .md-icon CSS rule
- Fixed mobile drawer back button (← Components) not showing when drilling into nav sections
- Fixed active page duplicating in the mobile drawer (e.g., "Grid System" appearing twice)
- Fixed GitHub link moving into the drawer on mobile — now stays in the header as icon-only below 960px
- Added search back arrow button visibility inside the search form
- Collapsed the search form container width on mobile to remove the dead gap between the search and GitHub icons
- Widened page grid to reduce excessive whitespace on large screens

### Why did you make the changes (we will use this info to test)?
<!-- Note: add lines if needed, and remove any unused lines -->  
  - The site had no usable navigation on narrow/mobile viewports — the hamburger button existed in the HTML but was invisible
- Users had no way to navigate back when drilling into nav sections (Components, Styles) on mobile
- The GitHub source link was disappearing from the header on mobile, breaking access to the repo
- The search experience on mobile lacked a visible close/back button
- The page layout felt cramped with too much dead space on the sides at larger screen widths

### Screenshots of Proposed Changes To The Website (if any, please do not include screenshots of code changes)
<!-- Notes: 
  - If there are no visual changes to the website, delete all of the script below and replace with "- No visual changes to the website"
  - If there are visual changes to the website, include the 'before' and 'after' screenshots below. 
  - If your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images
  - If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag 
 --> 

<details>
<summary>Visuals before changes are applied</summary>
<img width="1467" height="834" alt="Screenshot 2026-05-08 at 1 30 51 PM" src="https://github.com/user-attachments/assets/9af54cd1-39ad-4421-b78b-1d886c9acb60" />



</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1046" height="738" alt="Screenshot 2026-05-08 at 1 28 54 PM" src="https://github.com/user-attachments/assets/b86644f0-c879-4239-bf28-b1dbab6cfb13" />
<img width="1018" height="689" alt="Screenshot 2026-05-08 at 1 29 30 PM" src="https://github.com/user-attachments/assets/aa841fee-1ac6-4a62-bce0-23cdf8103e17" />
<img width="1462" height="832" alt="Screenshot 2026-05-08 at 1 29 59 PM" src="https://github.com/user-attachments/assets/6efee432-3879-4c0c-94ee-82d245d71d16" />

</details>
