### PR TITLE
Typography#2

### DIFF
--- a/docs/components/sass/components/_type-scale.scss
+++ b/docs/components/sass/components/_type-scale.scss
@@ -1,5 +1,40 @@
 @use '../abstracts/variables' as *;
 
+.type-grid-6 {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 0.8fr;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 1rem 0;
+
+  .type-grid-items {
+    padding: 12px 16px;
+    font-size: 0.875rem;
+    color: #37474f;
+    border-bottom: 1px solid #e8e8e8;
+    display: flex;
+    align-items: center;
+    background-color: #fff;
+
+    &:nth-child(-n+6) {
+      background-color: #f5f5f5;
+      color: #757575;
+      font-size: 0.8rem;
+      border-bottom: 1px solid #d0d0d0;
+    }
+
+    &:nth-child(12n+13),
+    &:nth-child(12n+14),
+    &:nth-child(12n+15),
+    &:nth-child(12n+16),
+    &:nth-child(12n+17),
+    &:nth-child(12n+18) {
+      background-color: #fafafa;
+    }
+  }
+}
+
 .desktop-examples {
 // --8<-- [start:desktop-hero-h1]
   .desktop-hero-h1 {

--- a/docs/components/sass/components/_type-scale.scss
+++ b/docs/components/sass/components/_type-scale.scss
@@ -1,8 +1,9 @@
 @use '../abstracts/variables' as *;
 
-.type-grid-6 {
+// Reference table grid (Class / Font Family / Size / Line height / Weight)
+.type-grid-5 {
   display: grid;
-  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 0.8fr;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
   overflow: hidden;
@@ -17,372 +18,71 @@
     align-items: center;
     background-color: #fff;
 
-    &:nth-child(-n+6) {
+    // header row
+    &:nth-child(-n+5) {
       background-color: #f5f5f5;
       color: #757575;
       font-size: 0.8rem;
       border-bottom: 1px solid #d0d0d0;
     }
 
-    &:nth-child(12n+13),
-    &:nth-child(12n+14),
-    &:nth-child(12n+15),
-    &:nth-child(12n+16),
-    &:nth-child(12n+17),
-    &:nth-child(12n+18) {
+    // zebra-stripe every other data row (5 cells per row)
+    &:nth-child(10n+11),
+    &:nth-child(10n+12),
+    &:nth-child(10n+13),
+    &:nth-child(10n+14),
+    &:nth-child(10n+15) {
       background-color: #fafafa;
     }
   }
 }
 
+// Shared base for every type token. Variants only override what changes
+// (size / weight / style), so there is no per-class boilerplate.
+%type-base {
+  display: block;
+  margin: 0.67em 0;
+  color: $text-color;
+}
+
+// Typography attaches to semantic elements — a consumer writes plain HTML
+// (<h1>, <p>, <strong>, <em>, <small>) and gets the correct token. No
+// utility classes required. "Hero" is a section context, not a per-line class.
+@mixin type-scale(
+  $h1, $h2, $h3, $h4, $h5, $p,
+  $hero-h1, $hero-p
+) {
+  h1 { @extend %type-base; font-size: $h1; font-weight: 700; }
+  h2 { @extend %type-base; font-size: $h2; font-weight: 600; }
+  h3 { @extend %type-base; font-size: $h3; font-weight: 600; }
+  h4 { @extend %type-base; font-size: $h4; font-weight: 600; }
+  h5 { @extend %type-base; font-size: $h5; font-weight: 600; }
+  p  { @extend %type-base; font-size: $p;  font-weight: 400; }
+
+  // inline variants via native semantic elements
+  small     { font-size: 0.75rem; }
+  strong, b { font-weight: 600; }
+  em, i     { font-style: italic; }
+
+  // hero section context
+  &.hero {
+    h1 { font-size: $hero-h1; font-weight: 700; }
+    p  { font-size: $hero-p; }
+  }
+}
+
 .desktop-examples {
-// --8<-- [start:desktop-hero-h1]
-  .desktop-hero-h1 {
-    display: block;
-    font-size: 3.25rem;
-    font-weight: bold;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-hero-h1]
-// --8<-- [start:desktop-hero-p]
-  .desktop-hero-p, .h1, h1{
-    display: block;
-    font-size: 1.5rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-hero-p]
-// --8<-- [start:desktop-hero-p-semibold]
-  .desktop-hero-p-semibold{
-    display: block;
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-hero-p-semibold]
-// --8<-- [start:desktop-hero-p-italic]
-  .desktop-hero-p-italic{
-    display: block;
-    font-size: 1.5rem;
-    font-style: italic;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-hero-p-italic]
-// --8<-- [start:desktop-body-h1]
-  .desktop-body-h1, .h1, h1{
-    display: block;
-    font-size: 2.5rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-h1]
-// --8<-- [start:desktop-body-h2]
-  .desktop-body-h2, .h2, h2{
-    display: block;
-    font-size: 2.25rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-h2]
-// --8<-- [start:desktop-body-h3]
-  .desktop-body-h3, .h3, h3{
-    display: block;
-    font-size: 1.75rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-h3]
-// --8<-- [start:desktop-body-h4]
-  .desktop-body-h4, .h4, h4{
-    display: block;
-    font-size: 1.5rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-h4]
-// --8<-- [start:desktop-body-h5]
-  .desktop-body-h5, .h5, h5{
-    display: block;
-    font-size: 1.25rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-h5]
-// --8<-- [start:desktop-body-p]
-  .desktop-body-p, .p, p{
-    display: block;
-    font-size: 1rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-p]
-// --8<-- [start:desktop-body-p-semibold]
-  .desktop-body-p-semibold{
-    display: block;
-    font-size: 1rem;
-    font-weight: 600;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-p-semibold]
-// --8<-- [start:desktop-body-p-italic]
-  .desktop-body-p-italic{
-    display: block;
-    font-size: 1rem;
-    font-style: italic;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-p-italic]
-// --8<-- [start:desktop-body-p-small]
-  .desktop-body-p-small{
-    display: block;
-    font-size: 0.75rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-p-small]
-// --8<-- [start:desktop-body-p-small-semibold]
-  .desktop-body-p-small-semibold{
-    display: block;
-    font-size: 0.75rem;
-    font-weight: 600;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-p-small-semibold]
-// --8<-- [start:desktop-body-p-small-italic]
-  .desktop-body-p-small-italic{
-    display: block;
-    font-size: 0.75rem;
-    font-style: italic;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:desktop-body-p-small-italic]
+  @include type-scale(
+    $h1: 3rem, $h2: 2.5rem, $h3: 2rem, $h4: 1.5rem, $h5: 1.25rem, $p: 1rem,
+    $hero-h1: 3.75rem, $hero-p: 1.5rem
+  );
 }
 
 .tablet-example {
-  // --8<-- [start:tablet-hero-h1]
-  .tablet-hero-h1 {
-    display: block;
-    font-size: 3rem;
-    font-weight: bold;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-hero-h1]
-// --8<-- [start:tablet-hero-p]
-  .tablet-hero-p{
-    display: block;
-    font-size: 1.25rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-hero-p]
-// --8<-- [start:tablet-hero-p-semibold]
-  .tablet-hero-p-semibold{
-    display: block;
-    font-size: 1.25rem;
-    font-weight: 600;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-hero-p-semibold]
-// --8<-- [start:tablet-hero-p-italic]
-  .tablet-hero-p-italic{
-    display: block;
-    font-size: 1.25rem;
-    font-style: italic;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-hero-p-italic]
-// --8<-- [start:tablet-body-h1]
-  .tablet-body-h1{
-    display: block;
-    font-size: 2.5rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-h1]
-// --8<-- [start:tablet-body-h2]
-  .tablet-body-h2{
-    display: block;
-    font-size: 2rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-h2]
-// --8<-- [start:tablet-body-h3]
-  .tablet-body-h3{
-    display: block;
-    font-size: 1.5rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-h3]
-// --8<-- [start:tablet-body-h4]
-  .tablet-body-h4{
-    display: block;
-    font-size: 1.25rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-h4]
-// --8<-- [start:tablet-body-h5]
-  .tablet-body-h5{
-    display: block;
-    font-size: 1rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-h5]
-// --8<-- [start:tablet-body-p]
-  .tablet-body-p{
-    display: block;
-    font-size: 1rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-p]
-// --8<-- [start:tablet-body-p-semibold]
-  .tablet-body-p-semibold{
-    display: block;
-    font-size: 1rem;
-    font-weight: 600;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-p-semibold]
-// --8<-- [start:tablet-body-p-italic]
-  .tablet-body-p-italic{
-    display: block;
-    font-size: 1rem;
-    font-style: italic;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-p-italic]
-// --8<-- [start:tablet-body-p-small]
-  .tablet-body-p-small{
-    display: block;
-    font-size: 0.75rem;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-p-small]
-// --8<-- [start:tablet-body-p-small-semibold]
-  .tablet-body-p-small-semibold{
-    display: block;
-    font-size: 0.75rem;
-    font-weight: 600;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-p-small-semibold]
-// --8<-- [start:tablet-body-p-small-italic]
-  .tablet-body-p-small-italic{
-    display: block;
-    font-size: 0.75rem;
-    font-style: italic;
-    margin-top: 0.67em;
-    margin-bottom: 0.67em;
-    margin-left: 0;
-    margin-right: 0;
-    color: $text-color;
-  }
-// --8<-- [end:tablet-body-p-small-italic]
+  @include type-scale(
+    $h1: 2.5rem, $h2: 2rem, $h3: 1.5rem, $h4: 1.25rem, $h5: 1rem, $p: 1rem,
+    $hero-h1: 3rem, $hero-p: 1.25rem
+  );
 }
 
 // styles for template page

--- a/docs/dist/main.css
+++ b/docs/dist/main.css
@@ -474,21 +474,6 @@ body {
   /* ============================================================
      Base Button
      ============================================================ */
-  /* ============================================================
-     Filled
-     ============================================================ */
-  /* ============================================================
-     Outline
-     ============================================================ */
-  /* ============================================================
-     Tonal
-     ============================================================ */
-  /* ============================================================
-     Text
-     ============================================================ */
-  /* ============================================================
-     X-Large (size modifier)
-     ============================================================ */
 }
 [data-theme] .button {
   appearance: none;
@@ -523,6 +508,11 @@ body {
   cursor: not-allowed;
   pointer-events: none;
 }
+[data-theme] {
+  /* ============================================================
+     Filled
+     ============================================================ */
+}
 [data-theme] .button-filled {
   background-color: var(--token-button-filled-bg);
   color: var(--token-button-filled-text);
@@ -539,6 +529,11 @@ body {
 [data-theme] .button-filled:disabled, [data-theme] .button-filled.disabled {
   background-color: var(--token-button-disabled-bg);
   color: var(--token-button-disabled-text);
+}
+[data-theme] {
+  /* ============================================================
+     Outline
+     ============================================================ */
 }
 [data-theme] .button-outline {
   background-color: transparent;
@@ -558,6 +553,11 @@ body {
   border-color: var(--token-outline-variant);
   color: var(--token-button-disabled-text);
 }
+[data-theme] {
+  /* ============================================================
+     Tonal
+     ============================================================ */
+}
 [data-theme] .button-tonal {
   background-color: var(--token-button-tonal-bg);
   color: var(--token-button-tonal-text);
@@ -575,6 +575,11 @@ body {
   background-color: var(--token-button-disabled-bg);
   color: var(--token-button-disabled-text);
 }
+[data-theme] {
+  /* ============================================================
+     Text
+     ============================================================ */
+}
 [data-theme] .button-text {
   background-color: transparent;
   color: var(--token-button-text-color);
@@ -591,6 +596,11 @@ body {
 [data-theme] .button-text:disabled, [data-theme] .button-text.disabled {
   background-color: var(--token-button-disabled-bg);
   color: var(--token-button-disabled-text);
+}
+[data-theme] {
+  /* ============================================================
+     X-Large (size modifier)
+     ============================================================ */
 }
 [data-theme] .button-xl {
   font-size: 1.5rem;
@@ -709,25 +719,13 @@ body {
   color: var(--token-radio-label-color-disabled);
 }
 
-[data-theme] {
-  /* ================= FIELD ================= */
-  /* ================= LABEL ================= */
-  /* ================= ICONS ================= */
-  /* ================= ICON PADDING ================= */
-  /* ================= SUPPORTING TEXT ================= */
-  /* ================= HOVER STATES ================= */
-  /* ================= FOCUS STATES ================= */
-  /* ================= ERROR STATES ================= */
-  /* Outlined error */
-  /* ================= DISABLED STATES ================= */
-  /* Outlined disabled */
-  /* ================= OUTLINED ================= */
-  /* ================= DEMO BOX ================= */
-}
 [data-theme] .input-wrapper {
   position: relative;
   width: var(--token-input-width);
   font-family: var(--text-font-stack);
+}
+[data-theme] {
+  /* ================= FIELD ================= */
 }
 [data-theme] .input-field {
   width: 100%;
@@ -749,6 +747,9 @@ body {
 [data-theme] .input-field::placeholder {
   color: transparent;
 }
+[data-theme] {
+  /* ================= LABEL ================= */
+}
 [data-theme] .input-label {
   position: absolute;
   left: 16px;
@@ -760,6 +761,9 @@ body {
   color: var(--token-input-label-color-focus);
   pointer-events: none;
   transition: 0.15s ease;
+}
+[data-theme] {
+  /* ================= ICONS ================= */
 }
 [data-theme] .input-icon {
   position: absolute;
@@ -782,6 +786,9 @@ body {
 [data-theme] .input-icon.trailing {
   right: 12px;
 }
+[data-theme] {
+  /* ================= ICON PADDING ================= */
+}
 [data-theme] .input-field.leading-icon {
   padding-left: 52px;
 }
@@ -797,6 +804,9 @@ body {
 [data-theme] .input-field:disabled ~ .input-icon {
   color: var(--token-input-icon-color-disabled);
 }
+[data-theme] {
+  /* ================= SUPPORTING TEXT ================= */
+}
 [data-theme] .input-helper {
   margin-top: 4px;
   margin-left: 16px;
@@ -809,12 +819,18 @@ body {
 [data-theme] .input-field:disabled ~ .input-helper {
   color: var(--token-input-supporting-color-disabled);
 }
+[data-theme] {
+  /* ================= HOVER STATES ================= */
+}
 [data-theme] .input-field.is-hover:hover {
   background: var(--token-input-filled-background-hover);
   border-bottom-color: var(--token-input-active-indicator-hover);
 }
 [data-theme] .input-wrapper.input-outlined .input-field.is-hover:hover {
   border-color: var(--token-input-outline-hover);
+}
+[data-theme] {
+  /* ================= FOCUS STATES ================= */
 }
 [data-theme] .input-field.is-focus:focus {
   border-bottom: 3px solid var(--token-input-active-indicator-focus);
@@ -828,6 +844,9 @@ body {
 [data-theme] .input-wrapper.input-outlined .input-field.is-focus:focus ~ .input-label {
   color: var(--token-input-label-color-focus);
 }
+[data-theme] {
+  /* ================= ERROR STATES ================= */
+}
 [data-theme] .input-field.error {
   border-bottom: 3px solid var(--token-input-active-indicator-error);
 }
@@ -840,8 +859,14 @@ body {
 [data-theme] .input-field.error ~ .input-icon.trailing {
   color: var(--token-input-icon-color-error);
 }
+[data-theme] {
+  /* Outlined error */
+}
 [data-theme] .input-wrapper.input-outlined .input-field.error {
   border: 3px solid var(--token-input-outline-error);
+}
+[data-theme] {
+  /* ================= DISABLED STATES ================= */
 }
 [data-theme] .input-field:disabled {
   border-bottom-color: var(--token-input-active-indicator-disabled);
@@ -857,8 +882,14 @@ body {
 [data-theme] .input-field:disabled ~ .input-icon {
   color: var(--token-input-icon-color-disabled);
 }
+[data-theme] {
+  /* Outlined disabled */
+}
 [data-theme] .input-wrapper.input-outlined .input-field:disabled {
   border-color: var(--token-input-outline-disabled);
+}
+[data-theme] {
+  /* ================= OUTLINED ================= */
 }
 [data-theme] .input-wrapper.input-outlined .input-field {
   background: #fff;
@@ -885,6 +916,9 @@ body {
 }
 [data-theme] .input-wrapper.input-outlined .input-field.leading-icon ~ .input-label {
   left: 16px;
+}
+[data-theme] {
+  /* ================= DEMO BOX ================= */
 }
 [data-theme] .state-box {
   width: 100%;
@@ -1052,15 +1086,15 @@ body {
   display: none;
 }
 
-.type-grid-6 {
+.type-grid-5 {
   display: grid;
-  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 0.8fr;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr;
   border: 1px solid #e0e0e0;
   border-radius: 4px;
   overflow: hidden;
   margin: 1rem 0;
 }
-.type-grid-6 .type-grid-items {
+.type-grid-5 .type-grid-items {
   padding: 12px 16px;
   font-size: 0.875rem;
   color: #37474f;
@@ -1069,300 +1103,102 @@ body {
   align-items: center;
   background-color: #fff;
 }
-.type-grid-6 .type-grid-items:nth-child(-n+6) {
+.type-grid-5 .type-grid-items:nth-child(-n+5) {
   background-color: #f5f5f5;
   color: #757575;
   font-size: 0.8rem;
   border-bottom: 1px solid #d0d0d0;
 }
-.type-grid-6 .type-grid-items:nth-child(12n+13), .type-grid-6 .type-grid-items:nth-child(12n+14), .type-grid-6 .type-grid-items:nth-child(12n+15), .type-grid-6 .type-grid-items:nth-child(12n+16), .type-grid-6 .type-grid-items:nth-child(12n+17), .type-grid-6 .type-grid-items:nth-child(12n+18) {
+.type-grid-5 .type-grid-items:nth-child(10n+11), .type-grid-5 .type-grid-items:nth-child(10n+12), .type-grid-5 .type-grid-items:nth-child(10n+13), .type-grid-5 .type-grid-items:nth-child(10n+14), .type-grid-5 .type-grid-items:nth-child(10n+15) {
   background-color: #fafafa;
 }
 
-.desktop-examples .desktop-hero-h1 {
+.tablet-example p, .tablet-example h5, .tablet-example h4, .tablet-example h3, .tablet-example h2, .tablet-example h1, .desktop-examples p, .desktop-examples h5, .desktop-examples h4, .desktop-examples h3, .desktop-examples h2, .desktop-examples h1 {
   display: block;
-  font-size: 3.25rem;
-  font-weight: bold;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-hero-p, .desktop-examples .h1, .desktop-examples h1 {
-  display: block;
-  font-size: 1.5rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-hero-p-semibold {
-  display: block;
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-hero-p-italic {
-  display: block;
-  font-size: 1.5rem;
-  font-style: italic;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-h1, .desktop-examples .h1, .desktop-examples h1 {
-  display: block;
-  font-size: 2.5rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-h2, .desktop-examples .h2, .desktop-examples h2 {
-  display: block;
-  font-size: 2.25rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-h3, .desktop-examples .h3, .desktop-examples h3 {
-  display: block;
-  font-size: 1.75rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-h4, .desktop-examples .h4, .desktop-examples h4 {
-  display: block;
-  font-size: 1.5rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-h5, .desktop-examples .h5, .desktop-examples h5 {
-  display: block;
-  font-size: 1.25rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-p, .desktop-examples .p, .desktop-examples p {
-  display: block;
-  font-size: 1rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-p-semibold {
-  display: block;
-  font-size: 1rem;
-  font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-p-italic {
-  display: block;
-  font-size: 1rem;
-  font-style: italic;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-p-small {
-  display: block;
-  font-size: 0.75rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-p-small-semibold {
-  display: block;
-  font-size: 0.75rem;
-  font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.desktop-examples .desktop-body-p-small-italic {
-  display: block;
-  font-size: 0.75rem;
-  font-style: italic;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
+  margin: 0.67em 0;
   color: #011F23;
 }
 
-.tablet-example .tablet-hero-h1 {
-  display: block;
+.desktop-examples h1 {
   font-size: 3rem;
-  font-weight: bold;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 700;
 }
-.tablet-example .tablet-hero-p {
-  display: block;
-  font-size: 1.25rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.tablet-example .tablet-hero-p-semibold {
-  display: block;
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.tablet-example .tablet-hero-p-italic {
-  display: block;
-  font-size: 1.25rem;
-  font-style: italic;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
-}
-.tablet-example .tablet-body-h1 {
-  display: block;
+.desktop-examples h2 {
   font-size: 2.5rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 600;
 }
-.tablet-example .tablet-body-h2 {
-  display: block;
+.desktop-examples h3 {
   font-size: 2rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 600;
 }
-.tablet-example .tablet-body-h3 {
-  display: block;
+.desktop-examples h4 {
   font-size: 1.5rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 600;
 }
-.tablet-example .tablet-body-h4 {
-  display: block;
+.desktop-examples h5 {
   font-size: 1.25rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 600;
 }
-.tablet-example .tablet-body-h5 {
-  display: block;
+.desktop-examples p {
   font-size: 1rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 400;
 }
-.tablet-example .tablet-body-p {
-  display: block;
-  font-size: 1rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+.desktop-examples small {
+  font-size: 0.75rem;
 }
-.tablet-example .tablet-body-p-semibold {
-  display: block;
+.desktop-examples strong, .desktop-examples b {
+  font-weight: 600;
+}
+.desktop-examples em, .desktop-examples i {
+  font-style: italic;
+}
+.desktop-examples.hero h1 {
+  font-size: 3.75rem;
+  font-weight: 700;
+}
+.desktop-examples.hero p {
+  font-size: 1.5rem;
+}
+
+.tablet-example h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+.tablet-example h2 {
+  font-size: 2rem;
+  font-weight: 600;
+}
+.tablet-example h3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+.tablet-example h4 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+.tablet-example h5 {
   font-size: 1rem;
   font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
 }
-.tablet-example .tablet-body-p-italic {
-  display: block;
+.tablet-example p {
   font-size: 1rem;
-  font-style: italic;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+  font-weight: 400;
 }
-.tablet-example .tablet-body-p-small {
-  display: block;
+.tablet-example small {
   font-size: 0.75rem;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
 }
-.tablet-example .tablet-body-p-small-semibold {
-  display: block;
-  font-size: 0.75rem;
+.tablet-example strong, .tablet-example b {
   font-weight: 600;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
 }
-.tablet-example .tablet-body-p-small-italic {
-  display: block;
-  font-size: 0.75rem;
+.tablet-example em, .tablet-example i {
   font-style: italic;
-  margin-top: 0.67em;
-  margin-bottom: 0.67em;
-  margin-left: 0;
-  margin-right: 0;
-  color: #011F23;
+}
+.tablet-example.hero h1 {
+  font-size: 3rem;
+  font-weight: 700;
+}
+.tablet-example.hero p {
+  font-size: 1.25rem;
 }
 
 .template-h1 {
@@ -1390,21 +1226,21 @@ label {
 /* --8<-- [start:dropdown-base] */
 [data-theme] {
   /* ================= WRAPPER ================= */
-  /* if dropdown also carries input-wrapper styles, remove inherited side padding */
-  /* ================= FIELD ================= */
-  /* ================= MENU ================= */
-  /* ================= OPEN STATE ================= */
-  /* ================= OPTIONS ================= */
-  /* ================= MKDOCS HARD RESET ================= */
 }
 [data-theme] .dropdown-wrapper {
   position: relative;
   width: var(--token-input-width);
   font-family: var(--text-font-stack);
 }
+[data-theme] {
+  /* if dropdown also carries input-wrapper styles, remove inherited side padding */
+}
 [data-theme] .dropdown-wrapper.input-wrapper {
   padding-left: 0 !important;
   padding-right: 0 !important;
+}
+[data-theme] {
+  /* ================= FIELD ================= */
 }
 [data-theme] .dropdown-field {
   position: relative;
@@ -1417,6 +1253,9 @@ label {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+[data-theme] {
+  /* ================= MENU ================= */
 }
 [data-theme] .dropdown-wrapper .dropdown-menu {
   position: absolute;
@@ -1435,8 +1274,14 @@ label {
   z-index: 20;
   overflow: hidden;
 }
+[data-theme] {
+  /* ================= OPEN STATE ================= */
+}
 [data-theme] .dropdown-wrapper.is-open .dropdown-menu {
   display: block;
+}
+[data-theme] {
+  /* ================= OPTIONS ================= */
 }
 [data-theme] .dropdown-option {
   display: flex;
@@ -1457,6 +1302,9 @@ label {
 }
 [data-theme] .dropdown-option.is-selected {
   background: rgba(36, 121, 132, 0.1);
+}
+[data-theme] {
+  /* ================= MKDOCS HARD RESET ================= */
 }
 [data-theme] .md-typeset .dropdown-wrapper ul.dropdown-menu,
 [data-theme] .md-typeset .dropdown-wrapper ul.dropdown-menu li {
@@ -1532,7 +1380,6 @@ label {
   flex-direction: row;
   justify-content: space-between;
   box-sizing: border-box;
-  list-style: none;
 }
 .accordion.-desktop > .summary > .title {
   margin: 0;
@@ -1549,6 +1396,9 @@ label {
   color: #006973;
   transition: transform 0.3s ease 0.1s;
   transform: rotate(0deg);
+}
+.accordion.-desktop > .summary {
+  list-style: none;
 }
 .accordion.-desktop > .summary::-webkit-details-marker {
   display: none;
@@ -1603,7 +1453,6 @@ label {
   align-items: center;
   flex-direction: row;
   justify-content: space-between;
-  list-style: none;
 }
 .accordion.-mobile > .summary > .title {
   margin: 0;
@@ -1620,6 +1469,9 @@ label {
   color: #006973;
   transition: transform 0.3s ease;
   transform: rotate(0deg);
+}
+.accordion.-mobile > .summary {
+  list-style: none;
 }
 .accordion.-mobile > .summary::-webkit-details-marker {
   display: none;
@@ -1653,7 +1505,6 @@ label {
   cursor: pointer;
   transition: 0.3s;
   /* pageicon can be <a> or <button> depending on JS */
-  /* focus is usually on inner button, so use focus-within */
 }
 [data-theme] .pagination .pagination-items .pagebutton .pageicon {
   display: flex;
@@ -1670,6 +1521,9 @@ label {
 }
 [data-theme] .pagination .pagination-items .pagebutton:hover, [data-theme] .pagination .pagination-items .pagebutton.hover {
   background-color: var(--token-pagination-bg-hover);
+}
+[data-theme] .pagination .pagination-items .pagebutton {
+  /* focus is usually on inner button, so use focus-within */
 }
 [data-theme] .pagination .pagination-items .pagebutton:focus-within, [data-theme] .pagination .pagination-items .pagebutton.focused {
   background-color: var(--token-pagination-bg-focus);
@@ -1916,19 +1770,6 @@ label {
   color: var(--token-chip-color-icon-secondary);
 }
 
-[data-md-color-scheme] {
-  /* Reset nav spacing */
-  /* Remove Material decorative title markers */
-  /* Hide duplicate nested back/title rows */
-  /* Hide TOC toggle label that duplicates the page title when active */
-  /* Hide inline TOC nav inside leaf items (Getting Started, FAQ) — TOC belongs in secondary sidebar */
-  /* ── Top-level items: Getting Started, FAQ (a), Styles, Components (label) ── */
-  /* No hover background on top-level items */
-  /* ── Child leaf links: Accordion, Buttons, Typography, etc. ── */
-  /* Hover only for child links */
-  /* Active page highlight */
-  /* Arrow icon */
-}
 [data-md-color-scheme] .md-sidebar--primary {
   border-right: none;
   --md-typeset-a-color: var(--token-on-surface, #1c1b1f);
@@ -1937,25 +1778,43 @@ label {
 [data-md-color-scheme] .md-sidebar--primary .md-sidebar__inner {
   padding: 16px 12px;
 }
+[data-md-color-scheme] {
+  /* Reset nav spacing */
+}
 [data-md-color-scheme] .md-sidebar--primary .md-nav,
 [data-md-color-scheme] .md-sidebar--primary .md-nav__list,
 [data-md-color-scheme] .md-sidebar--primary .md-nav__item {
   margin: 0;
   padding: 0;
 }
+[data-md-color-scheme] {
+  /* Remove Material decorative title markers */
+}
 [data-md-color-scheme] .md-sidebar--primary .md-nav__title::before,
 [data-md-color-scheme] .md-sidebar--primary .md-nav__title::after {
   display: none;
   content: none;
 }
+[data-md-color-scheme] {
+  /* Hide duplicate nested back/title rows */
+}
 [data-md-color-scheme] .md-sidebar--primary .md-nav .md-nav__title {
   display: none;
+}
+[data-md-color-scheme] {
+  /* Hide TOC toggle label that duplicates the page title when active */
 }
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link--active {
   display: none !important;
 }
+[data-md-color-scheme] {
+  /* Hide inline TOC nav inside leaf items (Getting Started, FAQ) — TOC belongs in secondary sidebar */
+}
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item:not(.md-nav__item--nested) > .md-nav {
   display: none !important;
+}
+[data-md-color-scheme] {
+  /* ── Top-level items: Getting Started, FAQ (a), Styles, Components (label) ── */
 }
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link,
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link {
@@ -1974,12 +1833,18 @@ label {
   border-radius: 0;
   box-shadow: none;
 }
+[data-md-color-scheme] {
+  /* No hover background on top-level items */
+}
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link:hover,
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > a.md-nav__link:focus,
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link:hover,
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="0"] > .md-nav__list > .md-nav__item > label.md-nav__link:focus {
   background-color: transparent !important;
   color: var(--token-on-surface, #1c1b1f) !important;
+}
+[data-md-color-scheme] {
+  /* ── Child leaf links: Accordion, Buttons, Typography, etc. ── */
 }
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link {
   min-height: 36px;
@@ -2000,12 +1865,18 @@ label {
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:visited {
   color: var(--token-on-surface-variant, #49454f) !important;
 }
+[data-md-color-scheme] {
+  /* Hover only for child links */
+}
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:hover,
 [data-md-color-scheme] .md-sidebar--primary .md-nav[data-md-level="1"] a.md-nav__link:focus {
   background-color: #d9e8eb !important;
   color: var(--token-on-surface, #1c1b1f) !important;
   box-shadow: none;
   text-decoration: none;
+}
+[data-md-color-scheme] {
+  /* Active page highlight */
 }
 [data-md-color-scheme] .md-sidebar--primary a.md-nav__link--active,
 [data-md-color-scheme] .md-sidebar--primary .md-nav__item--active > a.md-nav__link,
@@ -2017,6 +1888,9 @@ label {
   font-weight: 600;
   box-shadow: none;
   border: 0;
+}
+[data-md-color-scheme] {
+  /* Arrow icon */
 }
 [data-md-color-scheme] .md-sidebar--primary .md-nav__icon {
   color: var(--token-on-surface, #1c1b1f) !important;

--- a/docs/dist/main.css
+++ b/docs/dist/main.css
@@ -1042,6 +1042,33 @@ body {
   display: none;
 }
 
+.type-grid-6 {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr 1fr 1fr 0.8fr;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 1rem 0;
+}
+.type-grid-6 .type-grid-items {
+  padding: 12px 16px;
+  font-size: 0.875rem;
+  color: #37474f;
+  border-bottom: 1px solid #e8e8e8;
+  display: flex;
+  align-items: center;
+  background-color: #fff;
+}
+.type-grid-6 .type-grid-items:nth-child(-n+6) {
+  background-color: #f5f5f5;
+  color: #757575;
+  font-size: 0.8rem;
+  border-bottom: 1px solid #d0d0d0;
+}
+.type-grid-6 .type-grid-items:nth-child(12n+13), .type-grid-6 .type-grid-items:nth-child(12n+14), .type-grid-6 .type-grid-items:nth-child(12n+15), .type-grid-6 .type-grid-items:nth-child(12n+16), .type-grid-6 .type-grid-items:nth-child(12n+17), .type-grid-6 .type-grid-items:nth-child(12n+18) {
+  background-color: #fafafa;
+}
+
 .desktop-examples .desktop-hero-h1 {
   display: block;
   font-size: 3.25rem;

--- a/docs/type-scale.md
+++ b/docs/type-scale.md
@@ -31,7 +31,7 @@ hide:
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Regular</p>
         <p class="type-grid-items">-</p>
-        <!-- Hero Section / p/bold -->
+        <!-- Hero Section / p/semibold -->
         <p class="type-grid-items">Hero Section/<br/>p/semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">24px / 1.5rem</p>
@@ -123,278 +123,6 @@ hide:
         <p class="type-grid-items">Regular</p>
         <p class="type-grid-items">Italic</p>
     </div>
-    <br/>
-
-    <h2 class="template-h2">Example</h2>
-
-    === "Hero Section/H1"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <h1 class="desktop-hero-h1">This is a heading 1 for the Hero Section Desktop Size</h1>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-hero-h1"
-            </style>
-
-            <h1 class="desktop-hero-h1">This is a heading 1 for the Hero Section Desktop Size<h1>
-        ```
-
-    === "Hero Section/p"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-hero-p">This is a paragraph for the Hero Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-hero-p"
-            </style>
-
-            <p class="desktop-hero-p">This is a paragraph for the Hero Section Desktop Size<p>
-        ```
-    === "Hero Section/p/semibold"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-hero-p-semibold">This is a semibold paragraph for the Hero Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-hero-p-semibold"
-            </style>
-
-            <p class="desktop-hero-p-semibold">This is a semibold paragraph for the Hero Section Desktop Size<p>
-        ```
-
-    === "Hero Section/p/italic"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-hero-p-italic">This is an italic paragraph for the Hero Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-hero-p-italic"
-            </style>
-
-            <p class="desktop-hero-p-italic">This is an italic paragraph for the Hero Section Desktop Size<p>
-        ```
-
-    === "Body/H1"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-h1">This is a heading 1 for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-h1"
-            </style>
-
-            <h1 class="desktop-body-h1">This is a heading 1 for the Body Section Desktop Size<h1>
-        ```
-
-    === "Body/H2"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <h2 class="desktop-body-h2">This is a heading 2 for the Body Section Desktop Size</h2>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-h2"
-            </style>
-
-            <h2 class="desktop-body-h2">This is a heading 2 for the Body Section Desktop Size<h2>
-        ```
-
-    === "Body/H3"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <h3 class="desktop-body-h3">This is a heading 3 for the Body Section Desktop Size</h3>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-h3"
-            </style>
-
-            <h3 class="desktop-body-h3">This is a heading 3 for the Body Section Desktop Size<h3>
-        ```
-
-    === "Body/H4"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <h4 class="desktop-body-h4">This is a heading 4 for the Body Section Desktop Size</h4>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-h4"
-            </style>
-
-            <h4 class="desktop-body-h4">This is a heading 4 for the Body Section Desktop Size<h4>
-        ```
-
-    === "Body/H5"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <h5 class="desktop-body-h5">This is a heading 5 for the Body Section Desktop Size</h5>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-h5"
-            </style>
-
-            <h5 class="desktop-body-h5">This is a heading 5 for the Body Section Desktop Size<h5>
-        ```
-
-    === "Body/p"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-p">This is a paragraph for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-p"
-            </style>
-
-            <p class="desktop-body-p">This is a paragraph for the Body Section Desktop Size<p>
-        ```
-
-    === "Body/p/semibold"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-p-semibold">This is a semibold paragraph for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-p-semibold"
-            </style>
-
-            <p class="desktop-body-p-semibold">This is a semibold paragraph for the Body Section Desktop Size<p>
-        ```
-
-    === "Body/p/italic"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-p-italic">This is an italic paragraph for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-p-italic"
-            </style>
-
-            <p class="desktop-body-p-italic">This is an italic paragraph for the Body Section Desktop Size<p>
-        ```
-
-    === "Body/p/small"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-p-small">This is a small paragraph for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-p-small"
-            </style>
-
-            <p class="desktop-body-p-small">This is a small paragraph for the Body Section Desktop Size<p>
-        ```
-
-    === "Body/p/small-semibold"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-p-small-semibold">This is a small semibold paragraph for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-p-small-semibold"
-            </style>
-
-            <p class="desktop-body-p-small-semibold">This is a small semibold paragraph for the Body Section Desktop Size<p>
-        ```
-
-    === "Body/p/small-italic"
-        <div class="btn-grid-1">
-            <div class="grid-items desktop-examples">
-                <p class="desktop-body-p-small-italic">This is a small italic paragraph for the Body Section Desktop Size</p>
-            </div>
-        </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:desktop-body-p-small-italic"
-            </style>
-
-            <p class="desktop-body-p-small-italic">This is a small italic paragraph for the Body Section Desktop Size<p>
-        ```
 
 === "Tablet / Mobile"
     <div class="type-grid-6">
@@ -418,7 +146,7 @@ hide:
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Regular</p>
         <p class="type-grid-items">-</p>
-        <!-- Hero Section / p/bold -->
+        <!-- Hero Section / p/semibold -->
         <p class="type-grid-items">Hero Section/<br/>p/semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">20px / 1.25rem</p>
@@ -510,275 +238,251 @@ hide:
         <p class="type-grid-items">Regular</p>
         <p class="type-grid-items">Italic</p>
     </div>
-    <br/>
 
-    <h2 class="template-h2">Example</h2>
+<br/>
 
-    === "Hero Section/H1"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <h1 class="tablet-hero-h1">This is a heading 1 for the Hero Section Tablet Size</h1>
-            </div>
+<h2 class="template-h2">Code</h2>
+
+=== "Hero Section/H1"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-hero-h1"
+        </style>
+
+        <h1 class="desktop-hero-h1">This is a heading 1 for the Hero Section Desktop Size</h1>
+    ```
+
+=== "Hero Section/p"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-hero-p"
+        </style>
+
+        <p class="desktop-hero-p">This is a paragraph for the Hero Section Desktop Size</p>
+    ```
+
+=== "Hero Section/p/semibold"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-hero-p-semibold"
+        </style>
+
+        <p class="desktop-hero-p-semibold">This is a semibold paragraph for the Hero Section Desktop Size</p>
+    ```
+
+=== "Hero Section/p/italic"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-hero-p-italic"
+        </style>
+
+        <p class="desktop-hero-p-italic">This is an italic paragraph for the Hero Section Desktop Size</p>
+    ```
+
+=== "Body/H1"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-h1"
+        </style>
+
+        <h1 class="desktop-body-h1">This is a heading 1 for the Body Section Desktop Size</h1>
+    ```
+
+=== "Body/H2"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-h2"
+        </style>
+
+        <h2 class="desktop-body-h2">This is a heading 2 for the Body Section Desktop Size</h2>
+    ```
+
+=== "Body/H3"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-h3"
+        </style>
+
+        <h3 class="desktop-body-h3">This is a heading 3 for the Body Section Desktop Size</h3>
+    ```
+
+=== "Body/H4"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-h4"
+        </style>
+
+        <h4 class="desktop-body-h4">This is a heading 4 for the Body Section Desktop Size</h4>
+    ```
+
+=== "Body/H5"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-h5"
+        </style>
+
+        <h5 class="desktop-body-h5">This is a heading 5 for the Body Section Desktop Size</h5>
+    ```
+
+=== "Body/p"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-p"
+        </style>
+
+        <p class="desktop-body-p">This is a paragraph for the Body Section Desktop Size</p>
+    ```
+
+=== "Body/p/semibold"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-p-semibold"
+        </style>
+
+        <p class="desktop-body-p-semibold">This is a semibold paragraph for the Body Section Desktop Size</p>
+    ```
+
+=== "Body/p/italic"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-p-italic"
+        </style>
+
+        <p class="desktop-body-p-italic">This is an italic paragraph for the Body Section Desktop Size</p>
+    ```
+
+=== "Body/p/small"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-p-small"
+        </style>
+
+        <p class="desktop-body-p-small">This is a small paragraph for the Body Section Desktop Size</p>
+    ```
+
+=== "Body/p/small-semibold"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-p-small-semibold"
+        </style>
+
+        <p class="desktop-body-p-small-semibold">This is a small semibold paragraph for the Body Section Desktop Size</p>
+    ```
+
+=== "Body/p/small-italic"
+    ```html
+        <style>
+        --8<-- "_type-scale.scss:desktop-body-p-small-italic"
+        </style>
+
+        <p class="desktop-body-p-small-italic">This is a small italic paragraph for the Body Section Desktop Size</p>
+    ```
+
+<br/>
+
+<h2 class="template-h2">Example</h2>
+
+=== "Hero Section/H1"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <h1 class="desktop-hero-h1">This is a heading 1 for the Hero Section Desktop Size</h1>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-hero-h1"
-            </style>
-
-            <h1 class="tablet-hero-h1">This is a heading 1 for the Hero Section Tablet Size<h1>
-        ```
-
-    === "Hero Section/p"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-hero-p">This is a paragraph for the Hero Section Tablet Size</p>
-            </div>
+=== "Hero Section/p"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-hero-p">This is a paragraph for the Hero Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-hero-p"
-            </style>
-
-            <p class="tablet-hero-p">This is a paragraph for the Hero Section Tablet Size<p>
-        ```
-    === "Hero Section/p/semibold"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-hero-p-semibold">This is a semibold paragraph for the Hero Section Tablet Size</p>
-            </div>
+=== "Hero Section/p/semibold"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-hero-p-semibold">This is a semibold paragraph for the Hero Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-hero-p-semibold"
-            </style>
-
-            <p class="tablet-hero-p-semibold">This is a semibold paragraph for the Hero Section Tablet Size<p>
-        ```
-
-    === "Hero Section/p/italic"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-hero-p-italic">This is an italic paragraph for the Hero Section Tablet Size</p>
-            </div>
+=== "Hero Section/p/italic"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-hero-p-italic">This is an italic paragraph for the Hero Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-hero-p-italic"
-            </style>
-
-            <p class="tablet-hero-p-italic">This is an italic paragraph for the Hero Section Tablet Size<p>
-        ```
-
-    === "Body/H1"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-h1">This is a heading 1 for the Body Section Tablet Size</p>
-            </div>
+=== "Body/H1"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <h1 class="desktop-body-h1">This is a heading 1 for the Body Section Desktop Size</h1>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-h1"
-            </style>
-
-            <h1 class="tablet-body-h1">This is a heading 1 for the Body Section Tablet Size<h1>
-        ```
-
-    === "Body/H2"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <h2 class="tablet-body-h2">This is a heading 2 for the Body Section Tablet Size</h2>
-            </div>
+=== "Body/H2"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <h2 class="desktop-body-h2">This is a heading 2 for the Body Section Desktop Size</h2>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-h2"
-            </style>
-
-            <h2 class="tablet-body-h2">This is a heading 2 for the Body Section Tablet Size<h2>
-        ```
-
-    === "Body/H3"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <h3 class="tablet-body-h3">This is a heading 3 for the Body Section Tablet Size</h3>
-            </div>
+=== "Body/H3"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <h3 class="desktop-body-h3">This is a heading 3 for the Body Section Desktop Size</h3>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-h3"
-            </style>
-
-            <h3 class="tablet-body-h3">This is a heading 3 for the Body Section Tablet Size<h3>
-        ```
-
-    === "Body/H4"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <h4 class="tablet-body-h4">This is a heading 4 for the Body Section Tablet Size</h4>
-            </div>
+=== "Body/H4"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <h4 class="desktop-body-h4">This is a heading 4 for the Body Section Desktop Size</h4>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-h4"
-            </style>
-
-            <h4 class="tablet-body-h4">This is a heading 4 for the Body Section Tablet Size<h4>
-        ```
-
-    === "Body/H5"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <h5 class="tablet-body-h5">This is a heading 5 for the Body Section Tablet Size</h5>
-            </div>
+=== "Body/H5"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <h5 class="desktop-body-h5">This is a heading 5 for the Body Section Desktop Size</h5>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-h5"
-            </style>
-
-            <h5 class="tablet-body-h5">This is a heading 5 for the Body Section Tablet Size<h5>
-        ```
-
-    === "Body/p"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-p">This is a paragraph for the Body Section Tablet Size</p>
-            </div>
+=== "Body/p"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-body-p">This is a paragraph for the Body Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-p"
-            </style>
-
-            <p class="tablet-body-p">This is a paragraph for the Body Section Tablet Size<p>
-        ```
-
-    === "Body/p/semibold"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-p-semibold">This is a semibold paragraph for the Body Section Tablet Size</p>
-            </div>
+=== "Body/p/semibold"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-body-p-semibold">This is a semibold paragraph for the Body Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-p-semibold"
-            </style>
-
-            <p class="tablet-body-p-semibold">This is a semibold paragraph for the Body Section Tablet Size<p>
-        ```
-
-    === "Body/p/italic"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-p-italic">This is an italic paragraph for the Body Section Tablet Size</p>
-            </div>
+=== "Body/p/italic"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-body-p-italic">This is an italic paragraph for the Body Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-p-italic"
-            </style>
-
-            <p class="tablet-body-p-italic">This is an italic paragraph for the Body Section Tablet Size<p>
-        ```
-
-    === "Body/p/small"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-p-small">This is a small paragraph for the Body Section Tablet Size</p>
-            </div>
+=== "Body/p/small"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-body-p-small">This is a small paragraph for the Body Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-p-small"
-            </style>
-
-            <p class="tablet-body-p-small">This is a small paragraph for the Body Section Tablet Size<p>
-        ```
-
-    === "Body/p/small-semibold"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-p-small-semibold">This is a small semibold paragraph for the Body Section Tablet Size</p>
-            </div>
+=== "Body/p/small-semibold"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-body-p-small-semibold">This is a small semibold paragraph for the Body Section Desktop Size</p>
         </div>
-        <br/>
+    </div>
 
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-p-small-semibold"
-            </style>
-
-            <p class="tablet-body-p-small-semibold">This is a small semibold paragraph for the Body Section Tablet Size<p>
-        ```
-
-    === "Body/p/small-italic"
-        <div class="btn-grid-1">
-            <div class="grid-items tablet-example">
-                <p class="tablet-body-p-small-italic">This is a small italic paragraph for the Body Section Tablet Size</p>
-            </div>
+=== "Body/p/small-italic"
+    <div class="btn-grid-1">
+        <div class="grid-items desktop-examples">
+            <p class="desktop-body-p-small-italic">This is a small italic paragraph for the Body Section Desktop Size</p>
         </div>
-        <br/>
-
-        <h2 class="template-h2">Code</h2>
-
-        ```html
-            <style>
-            --8<-- "_type-scale.scss:tablet-body-p-small-italic"
-            </style>
-
-            <p class="tablet-body-p-small-italic">This is a small italic paragraph for the Body Section Tablet Size<p>
-        ```
+    </div>

--- a/docs/type-scale.md
+++ b/docs/type-scale.md
@@ -10,233 +10,201 @@ hide:
 <h2 class="template-h2">Device</h2>
 
 === "Desktop"
-    <div class="type-grid-6">
+    <div class="type-grid-5">
         <p class="type-grid-items">Class</p>
         <p class="type-grid-items">Font Family</p>
         <p class="type-grid-items">Size</p>
         <p class="type-grid-items">Line height</p>
         <p class="type-grid-items">Weight</p>
-        <p class="type-grid-items">Style</p>
         <!-- Hero Section / H1 -->
         <p class="type-grid-items">Hero Section/<br>H1</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">60px / 3.75rem</p>
         <p class="type-grid-items">120%</p>
         <p class="type-grid-items">Bold</p>
-        <p class="type-grid-items">-</p>
         <!-- Hero Section / p -->
         <p class="type-grid-items">Hero Section/<br/>p</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">24px / 1.5rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">-</p>
         <!-- Hero Section / p/semibold -->
         <p class="type-grid-items">Hero Section/<br/>p/semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">24px / 1.5rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Hero Section / p/italic -->
         <p class="type-grid-items">Hero Section/<br/>p/italic</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">24px / 1.5rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">Italic</p>
         <!-- Body Section / H1 -->
         <p class="type-grid-items">Body/<br/>H1</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">48px / 3rem</p>
         <p class="type-grid-items">120%</p>
         <p class="type-grid-items">Bold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H2 -->
         <p class="type-grid-items">Body/<br/>H2</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">40px / 2.5rem</p>
         <p class="type-grid-items">125%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H3 -->
         <p class="type-grid-items">Body/<br/>H3</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">32px / 2rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H4 -->
         <p class="type-grid-items">Body/<br/>H4</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">24px / 1.5rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H5 -->
         <p class="type-grid-items">Body/<br/>H5</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">20px / 1.25rem</p>
         <p class="type-grid-items">135%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p -->
         <p class="type-grid-items">Body/<br/>p</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/semibold -->
         <p class="type-grid-items">Body/<br/>p/semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/italic -->
         <p class="type-grid-items">Body/<br/>p/italic</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">Italic</p>
         <!-- Body Section / p/small -->
         <p class="type-grid-items">Body/<br/>p/small</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">12px / 0.75rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/small-semibold -->
         <p class="type-grid-items">Body/<br/>p/small-semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">12px / 0.75rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/small-italic -->
         <p class="type-grid-items">Body/<br/>p/small-italic</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">12px / 0.75rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">Italic</p>
     </div>
 
 === "Tablet / Mobile"
-    <div class="type-grid-6">
+    <div class="type-grid-5">
         <p class="type-grid-items">Class</p>
         <p class="type-grid-items">Font Family</p>
         <p class="type-grid-items">Size</p>
         <p class="type-grid-items">Line height</p>
         <p class="type-grid-items">Weight</p>
-        <p class="type-grid-items">Style</p>
         <!-- Hero Section / H1 -->
         <p class="type-grid-items">Hero Section/<br>H1</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">48px / 3rem</p>
         <p class="type-grid-items">120%</p>
         <p class="type-grid-items">Bold</p>
-        <p class="type-grid-items">-</p>
         <!-- Hero Section / p -->
         <p class="type-grid-items">Hero Section/<br/>p</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">20px / 1.25rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">-</p>
         <!-- Hero Section / p/semibold -->
         <p class="type-grid-items">Hero Section/<br/>p/semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">20px / 1.25rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Hero Section / p/italic -->
         <p class="type-grid-items">Hero Section/<br/>p/italic</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">20px / 1.25rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">Italic</p>
         <!-- Body Section / H1 -->
         <p class="type-grid-items">Body/<br/>H1</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">40px / 2.5rem</p>
         <p class="type-grid-items">120%</p>
         <p class="type-grid-items">Bold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H2 -->
         <p class="type-grid-items">Body/<br/>H2</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">32px / 2rem</p>
         <p class="type-grid-items">125%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H3 -->
         <p class="type-grid-items">Body/<br/>H3</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">24px / 1.5rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H4 -->
         <p class="type-grid-items">Body/<br/>H4</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">20px / 1.25rem</p>
         <p class="type-grid-items">130%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / H5 -->
         <p class="type-grid-items">Body/<br/>H5</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">135%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p -->
         <p class="type-grid-items">Body/<br/>p</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/semibold -->
         <p class="type-grid-items">Body/<br/>p/semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/italic -->
         <p class="type-grid-items">Body/<br/>p/italic</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">16px / 1rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">Italic</p>
         <!-- Body Section / p/small -->
         <p class="type-grid-items">Body/<br/>p/small</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">12px / 0.75rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/small-semibold -->
         <p class="type-grid-items">Body/<br/>p/small-semibold</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">12px / 0.75rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Semibold</p>
-        <p class="type-grid-items">-</p>
         <!-- Body Section / p/small-italic -->
         <p class="type-grid-items">Body/<br/>p/small-italic</p>
         <p class="type-grid-items">Roboto</p>
         <p class="type-grid-items">12px / 0.75rem</p>
         <p class="type-grid-items">150%</p>
         <p class="type-grid-items">Regular</p>
-        <p class="type-grid-items">Italic</p>
     </div>
 
 <br/>
@@ -245,137 +213,85 @@ hide:
 
 === "Hero Section/H1"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-hero-h1"
-        </style>
-
-        <h1 class="desktop-hero-h1">This is a heading 1 for the Hero Section Desktop Size</h1>
+    <section class="hero">
+      <h1>This is a heading 1 for the Hero Section</h1>
+    </section>
     ```
 
 === "Hero Section/p"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-hero-p"
-        </style>
-
-        <p class="desktop-hero-p">This is a paragraph for the Hero Section Desktop Size</p>
+    <section class="hero">
+      <p>This is a paragraph for the Hero Section</p>
+    </section>
     ```
 
 === "Hero Section/p/semibold"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-hero-p-semibold"
-        </style>
-
-        <p class="desktop-hero-p-semibold">This is a semibold paragraph for the Hero Section Desktop Size</p>
+    <section class="hero">
+      <p><strong>This is a semibold paragraph for the Hero Section</strong></p>
+    </section>
     ```
 
 === "Hero Section/p/italic"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-hero-p-italic"
-        </style>
-
-        <p class="desktop-hero-p-italic">This is an italic paragraph for the Hero Section Desktop Size</p>
+    <section class="hero">
+      <p><em>This is an italic paragraph for the Hero Section</em></p>
+    </section>
     ```
 
 === "Body/H1"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-h1"
-        </style>
-
-        <h1 class="desktop-body-h1">This is a heading 1 for the Body Section Desktop Size</h1>
+    <h1>This is a heading 1 for the Body Section</h1>
     ```
 
 === "Body/H2"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-h2"
-        </style>
-
-        <h2 class="desktop-body-h2">This is a heading 2 for the Body Section Desktop Size</h2>
+    <h2>This is a heading 2 for the Body Section</h2>
     ```
 
 === "Body/H3"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-h3"
-        </style>
-
-        <h3 class="desktop-body-h3">This is a heading 3 for the Body Section Desktop Size</h3>
+    <h3>This is a heading 3 for the Body Section</h3>
     ```
 
 === "Body/H4"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-h4"
-        </style>
-
-        <h4 class="desktop-body-h4">This is a heading 4 for the Body Section Desktop Size</h4>
+    <h4>This is a heading 4 for the Body Section</h4>
     ```
 
 === "Body/H5"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-h5"
-        </style>
-
-        <h5 class="desktop-body-h5">This is a heading 5 for the Body Section Desktop Size</h5>
+    <h5>This is a heading 5 for the Body Section</h5>
     ```
 
 === "Body/p"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-p"
-        </style>
-
-        <p class="desktop-body-p">This is a paragraph for the Body Section Desktop Size</p>
+    <p>This is a paragraph for the Body Section</p>
     ```
 
 === "Body/p/semibold"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-p-semibold"
-        </style>
-
-        <p class="desktop-body-p-semibold">This is a semibold paragraph for the Body Section Desktop Size</p>
+    <p><strong>This is a semibold paragraph for the Body Section</strong></p>
     ```
 
 === "Body/p/italic"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-p-italic"
-        </style>
-
-        <p class="desktop-body-p-italic">This is an italic paragraph for the Body Section Desktop Size</p>
+    <p><em>This is an italic paragraph for the Body Section</em></p>
     ```
 
 === "Body/p/small"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-p-small"
-        </style>
-
-        <p class="desktop-body-p-small">This is a small paragraph for the Body Section Desktop Size</p>
+    <small>This is a small paragraph for the Body Section</small>
     ```
 
 === "Body/p/small-semibold"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-p-small-semibold"
-        </style>
-
-        <p class="desktop-body-p-small-semibold">This is a small semibold paragraph for the Body Section Desktop Size</p>
+    <small><strong>This is a small semibold paragraph for the Body Section</strong></small>
     ```
 
 === "Body/p/small-italic"
     ```html
-        <style>
-        --8<-- "_type-scale.scss:desktop-body-p-small-italic"
-        </style>
-
-        <p class="desktop-body-p-small-italic">This is a small italic paragraph for the Body Section Desktop Size</p>
+    <small><em>This is a small italic paragraph for the Body Section</em></small>
     ```
 
 <br/>
@@ -384,105 +300,105 @@ hide:
 
 === "Hero Section/H1"
     <div class="btn-grid-1">
-        <div class="grid-items desktop-examples">
-            <h1 class="desktop-hero-h1">This is a heading 1 for the Hero Section Desktop Size</h1>
+        <div class="grid-items desktop-examples hero">
+            <h1>This is a heading 1 for the Hero Section</h1>
         </div>
     </div>
 
 === "Hero Section/p"
     <div class="btn-grid-1">
-        <div class="grid-items desktop-examples">
-            <p class="desktop-hero-p">This is a paragraph for the Hero Section Desktop Size</p>
+        <div class="grid-items desktop-examples hero">
+            <p>This is a paragraph for the Hero Section</p>
         </div>
     </div>
 
 === "Hero Section/p/semibold"
     <div class="btn-grid-1">
-        <div class="grid-items desktop-examples">
-            <p class="desktop-hero-p-semibold">This is a semibold paragraph for the Hero Section Desktop Size</p>
+        <div class="grid-items desktop-examples hero">
+            <p><strong>This is a semibold paragraph for the Hero Section</strong></p>
         </div>
     </div>
 
 === "Hero Section/p/italic"
     <div class="btn-grid-1">
-        <div class="grid-items desktop-examples">
-            <p class="desktop-hero-p-italic">This is an italic paragraph for the Hero Section Desktop Size</p>
+        <div class="grid-items desktop-examples hero">
+            <p><em>This is an italic paragraph for the Hero Section</em></p>
         </div>
     </div>
 
 === "Body/H1"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <h1 class="desktop-body-h1">This is a heading 1 for the Body Section Desktop Size</h1>
+            <h1>This is a heading 1 for the Body Section</h1>
         </div>
     </div>
 
 === "Body/H2"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <h2 class="desktop-body-h2">This is a heading 2 for the Body Section Desktop Size</h2>
+            <h2>This is a heading 2 for the Body Section</h2>
         </div>
     </div>
 
 === "Body/H3"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <h3 class="desktop-body-h3">This is a heading 3 for the Body Section Desktop Size</h3>
+            <h3>This is a heading 3 for the Body Section</h3>
         </div>
     </div>
 
 === "Body/H4"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <h4 class="desktop-body-h4">This is a heading 4 for the Body Section Desktop Size</h4>
+            <h4>This is a heading 4 for the Body Section</h4>
         </div>
     </div>
 
 === "Body/H5"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <h5 class="desktop-body-h5">This is a heading 5 for the Body Section Desktop Size</h5>
+            <h5>This is a heading 5 for the Body Section</h5>
         </div>
     </div>
 
 === "Body/p"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <p class="desktop-body-p">This is a paragraph for the Body Section Desktop Size</p>
+            <p>This is a paragraph for the Body Section</p>
         </div>
     </div>
 
 === "Body/p/semibold"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <p class="desktop-body-p-semibold">This is a semibold paragraph for the Body Section Desktop Size</p>
+            <p><strong>This is a semibold paragraph for the Body Section</strong></p>
         </div>
     </div>
 
 === "Body/p/italic"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <p class="desktop-body-p-italic">This is an italic paragraph for the Body Section Desktop Size</p>
+            <p><em>This is an italic paragraph for the Body Section</em></p>
         </div>
     </div>
 
 === "Body/p/small"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <p class="desktop-body-p-small">This is a small paragraph for the Body Section Desktop Size</p>
+            <small>This is a small paragraph for the Body Section</small>
         </div>
     </div>
 
 === "Body/p/small-semibold"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <p class="desktop-body-p-small-semibold">This is a small semibold paragraph for the Body Section Desktop Size</p>
+            <small><strong>This is a small semibold paragraph for the Body Section</strong></small>
         </div>
     </div>
 
 === "Body/p/small-italic"
     <div class="btn-grid-1">
         <div class="grid-items desktop-examples">
-            <p class="desktop-body-p-small-italic">This is a small italic paragraph for the Body Section Desktop Size</p>
+            <small><em>This is a small italic paragraph for the Body Section</em></small>
         </div>
     </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,8 @@ theme:
   font:
     text: roboto
   logo: Logo Flatten White.png
+  icon:
+    repo: fontawesome/brands/github
   features:
     # - navigation.expand
     - navigation.instant


### PR DESCRIPTION
<!--  Important! Add the number of the issue you worked on  --> 
Fixes #742
https://github.com/hackforla/internship/issues/742

### What changes did you make?

 - Removed the "Style" column from both the Desktop and Tablet/Mobile Device tables (type-grid-6 → type-grid-5), since the italic/regular info was already implied by the token names.
- Stripped the inline <style> blocks and --8<-- "_type-scale.scss:..." SCSS includes out of every token in the Code tab.
- Replaced all per-token utility classes (desktop-body-h1, desktop-hero-p-italic, etc.) with plain semantic HTML — for semibold, <em> for italic, <small> for small text.
- Wrapped Hero tokens in <section class="hero"> and added the hero class to the Hero example containers so styling comes from section context instead of classes.
- Deleted the now-unused device-specific rules from _type-scale.scss and main.css, and shortened the sample copy ("...Desktop Size" → "...Section").
- Fixed the GitHub logo in Navbar

### Why did you make the changes (we will use this info to test)?

  - To simplify the type-scale microsite so tokens are documented as clean semantic HTML that inherits from the design system's base styles rather than one-off classes.
- To remove redundant/duplicated data (the Style column and repeated inline styles) and keep the tables easier to read.
- To cut ~880 lines of unused SCSS/CSS and inline style injection, making the page easier to maintain.
- Testing: verify the Type Scale page still renders correctly in both Desktop and Tablet/Mobile tabs, that every Code snippet matches its Example preview, and that Hero vs Body typography still displays at the documented sizes/weights.


<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1076" height="926" alt="Screenshot 2026-07-02 at 1 55 28 PM" src="https://github.com/user-attachments/assets/458a087a-0bae-4260-ba0a-c89940611441" />



</details>
